### PR TITLE
프롤로그와 에필로그 배경전환을 ChangeImage에게 역할위임

### DIFF
--- a/Workpiece/Summoner/Assets/Screen/Pro_Epi Screen.unity
+++ b/Workpiece/Summoner/Assets/Screen/Pro_Epi Screen.unity
@@ -221,6 +221,7 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 508d81cf1f0d026429f9bb5833e07502, type: 3}
   - {fileID: 21300000, guid: 6da78eacc12b2394092b352fd777e80a, type: 3}
   targetImage: {fileID: 430804887}
+  interactionController: {fileID: 900800007}
 --- !u!1 &487251043
 GameObject:
   m_ObjectHideFlags: 0
@@ -355,7 +356,6 @@ MonoBehaviour:
   characterName: {fileID: 487251044}
   dialogueContext: {fileID: 1610194284}
   interactionEvent: {fileID: 900800006}
-  changeImage: {fileID: 430804889}
 --- !u!114 &900800008
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -479,6 +479,7 @@ MonoBehaviour:
   - {fileID: 21300000, guid: c2f36ff770254c94581206701ae66d2a, type: 3}
   - {fileID: 21300000, guid: 7c8c1ad20bce5a545a469f62bcbb424b, type: 3}
   targetImage: {fileID: 430804887}
+  interactionController: {fileID: 0}
 --- !u!1 &962638434
 GameObject:
   m_ObjectHideFlags: 0

--- a/Workpiece/Summoner/Assets/Screen/Story Screen.unity
+++ b/Workpiece/Summoner/Assets/Screen/Story Screen.unity
@@ -643,6 +643,7 @@ RectTransform:
   - {fileID: 1643105481}
   - {fileID: 666924675}
   - {fileID: 1102135333}
+  - {fileID: 358649452}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -907,6 +908,41 @@ RectTransform:
   - {fileID: 1822678068}
   - {fileID: 2097610757}
   m_Father: {fileID: 2131420636}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &358649451
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 358649452}
+  m_Layer: 5
+  m_Name: StoryController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &358649452
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 358649451}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 268141388}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2700,7 +2736,6 @@ MonoBehaviour:
   characterName: {fileID: 1729739219}
   dialogueContext: {fileID: 1211233011}
   interactionEvent: {fileID: 1102135334}
-  changeImage: {fileID: 0}
 --- !u!114 &1102135336
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Workpiece/Summoner/Assets/Script/Story/ChangeImage.cs
+++ b/Workpiece/Summoner/Assets/Script/Story/ChangeImage.cs
@@ -11,9 +11,21 @@ public class ChangeImage : MonoBehaviour
     [Header("받은 Sprite를 넣을 Image오브젝트")]
     [SerializeField] private Image targetImage;
 
-    public void ShowImage(int number)
+    [Header("Interaction Controller 참조")]
+    [SerializeField] private InteractionController interactionController; // InteractionController 참조
+
+    public void ShowImage()
     {
-        Debug.Log(number);
-        targetImage.sprite = spriteArray[number];
+        int currentDialogueIndex = interactionController.getCurrentDialogueIndex(); // currentDialogueIndex 가져오기
+        Debug.Log(currentDialogueIndex);
+
+        if (currentDialogueIndex >= 0 && currentDialogueIndex < spriteArray.Length)
+        {
+            targetImage.sprite = spriteArray[currentDialogueIndex];
+        }
+        else
+        {
+            Debug.LogWarning("유효하지 않은 인덱스입니다.");
+        }
     }
 }

--- a/Workpiece/Summoner/Assets/Script/Story/InteractionController.cs
+++ b/Workpiece/Summoner/Assets/Script/Story/InteractionController.cs
@@ -11,7 +11,6 @@ public class InteractionController : MonoBehaviour, IPointerClickHandler
     public Text dialogueContext;
 
     [SerializeField] private InteractionEvent interactionEvent; // InteractionEvent 연결
-    [SerializeField] private ChangeImage changeImage; // ChangeImage 연결
 
     private Dialogue[] currentDialogues; // 현재 진행 중인 대화
     private int currentDialogueIndex = 0; // 현재 진행 중인 Dialogue 인덱스(CSV의 ID순서)
@@ -54,7 +53,6 @@ public class InteractionController : MonoBehaviour, IPointerClickHandler
         if (currentDialogueIndex < currentDialogues.Length)
         {
             Dialogue currentDialogue = currentDialogues[currentDialogueIndex]; //읽어들일 Dialogue를 가져온다.
-            changeImage.ShowImage(currentDialogueIndex); // 대사 인덱스 (CSV의 ID)에 따라 이미지를 변경
 
             // 현재 캐릭터의 모든 대사를 출력했다면 다음 캐릭터(CSV의 ID)로 넘어감
             if (currentDialogueLineIndex >= currentDialogue.context.Length)
@@ -126,4 +124,15 @@ public class InteractionController : MonoBehaviour, IPointerClickHandler
     {
         ShowNextLine();
     }
+
+    public int getCurrentDialogueIndex()
+    {
+        return currentDialogueIndex;
+    }
+
+    public int getCurrentDialogueLineIndex()
+    {
+        return currentDialogueLineIndex;
+    }
+
 }

--- a/Workpiece/Summoner/Assets/Script/Story/Stage1_Controller.cs
+++ b/Workpiece/Summoner/Assets/Script/Story/Stage1_Controller.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Stage1_Controller : MonoBehaviour
+{
+    
+}

--- a/Workpiece/Summoner/Assets/Script/Story/Stage1_Controller.cs.meta
+++ b/Workpiece/Summoner/Assets/Script/Story/Stage1_Controller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c29d1edd306de0c4d8a17aebcd2c72db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workpiece/Summoner/Assets/Script/Story/Story.cs
+++ b/Workpiece/Summoner/Assets/Script/Story/Story.cs
@@ -6,7 +6,6 @@ using UnityEngine.UI;
 
 public class Story : MonoBehaviour
 {
-
     [Header("스킵하시겠습니까? 창")]
     public GameObject alertSkip;    // 스킵 창 띄울 오브젝트
     public Alert alertSkipResult; 


### PR DESCRIPTION
1. 프롤로그 에필로그 배경전환을 기존엔 Interaction컨트롤러에 nextDialogue메소드에서 했지만 이 메소드가 할 역할이 다른 씬에서도 있고 Story씬에서는 배경전환 될 일이 적고 ID를 키값으로 해서 전환되지 않기때문에 역할을 넘김

2. 스토리 애니메이션 구성계획 각 씬마다 <Stage+"숫자"_Controller>라는 스크립트를 만들어서 필요한 오브젝트들을 할당해주고 Dialogue에 맞는 장면을 연출시킬 계획.