### PR TITLE
재소환 로직 수정

### DIFF
--- a/Workpiece/Summoner/Assets/Screen/Fight Screen.unity
+++ b/Workpiece/Summoner/Assets/Screen/Fight Screen.unity
@@ -1375,6 +1375,10 @@ MonoBehaviour:
   darkenBackground: {fileID: 557547359}
   selectSummonPanels:
   - {fileID: 1178627254}
+  ReselectSummonPanels:
+  - {fileID: 1434509436}
+  - {fileID: 1152497999}
+  - {fileID: 21840651}
 --- !u!114 &299313757 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7001086004006574865, guid: 425618ad78d48fc47930e89c04062585, type: 3}

--- a/Workpiece/Summoner/Assets/Script/TestScript/PickSummonPanel.cs
+++ b/Workpiece/Summoner/Assets/Script/TestScript/PickSummonPanel.cs
@@ -60,9 +60,6 @@ public class PickSummonPanel : MonoBehaviour,
         assignedSummon = null;
     }
 
-
-
-
     public Summon getAssignedSummon()
     {
         return assignedSummon;

--- a/Workpiece/Summoner/Assets/Script/TestScript/Plate.cs
+++ b/Workpiece/Summoner/Assets/Script/TestScript/Plate.cs
@@ -63,15 +63,6 @@ public class Plate : MonoBehaviour,
         }
     }
 
-    // 체력 체크 (플레이트 위 소환수의 체력 확인)
-    public void CheckHealth()
-    {
-        if (currentSummon != null)
-        {
-            Debug.Log($"소환수 {currentSummon.summonName} 의 체력: {currentSummon.nowHP}");
-        }
-    }
-
     // 플레이트 강조 (색상 변경)
     public void Highlight()
     {
@@ -92,7 +83,7 @@ public class Plate : MonoBehaviour,
         {
             SetSummonImageTransparency(1.0f); // 투명도를 높여 더 진하게 보이게
         }
-        if (isInSummon && summonController.IsResummoning()) // 재소환 중이고 소환수가 있는 경우
+        if (isInSummon && summonController.IsReSummoning()) // 재소환 중이고 소환수가 있는 경우
         {
             Highlight(); // 플레이트 강조
             SetSummonImageTransparency(1.0f); // 투명도 높이기
@@ -103,7 +94,7 @@ public class Plate : MonoBehaviour,
     //마우스가 벗어날때
     public void OnPointerExit(PointerEventData eventData)
     {
-        if (currentSummon != null && summonController.IsResummoning()) //재소환중일때 더 진하게
+        if (currentSummon != null && summonController.IsReSummoning()) //재소환중일때 더 진하게
         {
             Unhighlight(); // 강조 해제
             SetSummonImageTransparency(0.5f); // 다시 흐리게
@@ -115,16 +106,17 @@ public class Plate : MonoBehaviour,
     public void OnPointerClick(PointerEventData eventData)
     {
         // 플레이어가 재소환 중이라면 상태 패널을 뜨지 않도록 함
-        if (summonController.IsResummoning() && isInSummon)
+        if (summonController.IsReSummoning() && isInSummon)
         {
                 summonController.SelectPlate(this);
+                Unhighlight(); // 강조 해제
+                SetSummonImageTransparency(1.0f); //투명도 되돌리기
         }
 
-        if (currentSummon != null && !summonController.IsResummoning())
+        else if (currentSummon != null && !summonController.IsReSummoning())
         {
             Debug.Log("클릭된 플레이트의 소환수:" + currentSummon.name);
-            CheckHealth();
-            statePanel.SetActive(true);
+            statePanel.SetActive(true); //상태 패널 활성화
             onMousePlateScript.setStatePanel(currentSummon); // 패널에 소환수 정보 전달 
         }
     }

--- a/Workpiece/Summoner/Assets/Script/TestScript/Player.cs
+++ b/Workpiece/Summoner/Assets/Script/TestScript/Player.cs
@@ -79,13 +79,17 @@ public class Player : Character
     public void OnReSummonBtnClick() //재소환 버튼 클릭
     {
         if (mana >= usedMana) {
-            summonController.StartResummon();
-            if (summonController.getIsSuccessSummon())
-            {
+            if (summonController.StartResummon())
+            { //재소환 시작
+              //마나 차감
                 mana -= usedMana;
                 usedMana += 1;
                 UpdateManaUI();
             }
+        }
+        else
+        {
+            Debug.Log("재소환시 필요한 마나가 모자랍니다.");
         }
     }
 


### PR DESCRIPTION
1. 재소환시 필요한 마나가 충분한지, 플레이트에 소환수가 1마리라도 있는지 검사하여 모두 충족하면 재소환을 실행한다.

2. 재소환시 소환수가 존재하는 플레이트를 강조시키며 플레이어는 해당 플레이트중 하나를 선택한다. 그럼 해당 플레이트에 재소환할 소환수 3가지중 선택할 기회를 주며 선택한 소환수를 그 자리에 재소환시킨다.