### PR TITLE
적 소환수의 자동공격 및 등급별 연속공격 구현

### DIFF
--- a/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen 1.unity
+++ b/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen 1.unity
@@ -1848,6 +1848,7 @@ GameObject:
   m_Component:
   - component: {fileID: 313031150}
   - component: {fileID: 313031151}
+  - component: {fileID: 313031152}
   m_Layer: 5
   m_Name: Enermy
   m_TagString: Untagged
@@ -1893,7 +1894,21 @@ MonoBehaviour:
   - {fileID: 1856290379}
   - {fileID: 792077600}
   turnController: {fileID: 893681170}
-  enermyAttackController: {fileID: 893681173}
+  enermyAttackController: {fileID: 313031152}
+--- !u!114 &313031152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  battleController: {fileID: 893681171}
+  plateController: {fileID: 893681172}
 --- !u!1 &323705123
 GameObject:
   m_ObjectHideFlags: 0
@@ -4521,7 +4536,6 @@ GameObject:
   - component: {fileID: 893681172}
   - component: {fileID: 893681171}
   - component: {fileID: 893681170}
-  - component: {fileID: 893681173}
   m_Layer: 5
   m_Name: Player_Enermy
   m_TagString: Untagged
@@ -4636,19 +4650,6 @@ MonoBehaviour:
   - {fileID: 9184813848463463012}
   - {fileID: 1856290379}
   - {fileID: 792077600}
---- !u!114 &893681173
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893681166}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  battleController: {fileID: 893681171}
 --- !u!1 &959924360
 GameObject:
   m_ObjectHideFlags: 0

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleController.cs
@@ -86,7 +86,7 @@ public class BattleController : MonoBehaviour
     {
         StatusType attackStatusType = targetedAttack.getStatusType();
 
-        if (isPlayer)
+        if (isPlayer) //플레이어
         {
             if (!IsValidPlateIndex(selectedPlateIndex, plateController.getEnermyPlates().Count))
             {
@@ -94,10 +94,10 @@ public class BattleController : MonoBehaviour
                 return;
             }
 
-            if (attackStatusType == StatusType.Heal)
+            if (attackStatusType == StatusType.Heal || attackStatusType == StatusType.Upgrade || attackStatusType == StatusType.Shield)
             {
-                attackSummon.SpecialAttack(plateController.getPlayerPlates(), selectedPlateIndex, selectSpecialAttackIndex); // 아군 플레이트에 힐
-                Debug.Log($"플레이어가 선택한 아군의 플레이트 {selectedPlateIndex}가 치유 대상입니다.");
+                attackSummon.SpecialAttack(plateController.getPlayerPlates(), selectedPlateIndex, selectSpecialAttackIndex); // 아군 플레이트에 이로운 효과
+                Debug.Log($"플레이어가 선택한 아군의 플레이트 {selectedPlateIndex}가 이로운 효과 대상입니다.");
             }
             else
             {
@@ -105,7 +105,7 @@ public class BattleController : MonoBehaviour
                 Debug.Log($"플레이어가 선택한 적의 플레이트 {selectedPlateIndex}가 공격 대상입니다.");
             }
         }
-        else
+        else //적
         {
             if (!IsValidPlateIndex(selectedPlateIndex, plateController.getPlayerPlates().Count))
             {
@@ -113,8 +113,17 @@ public class BattleController : MonoBehaviour
                 return;
             }
 
-            attackSummon.SpecialAttack(plateController.getPlayerPlates(), selectedPlateIndex, selectSpecialAttackIndex); // 적이 플레이어 플레이트에 공격
-            Debug.Log($"적이 플레이어의 플레이트 {selectedPlateIndex}를 공격합니다.");
+            if (attackStatusType == StatusType.Heal || attackStatusType == StatusType.Upgrade || attackStatusType == StatusType.Shield)
+            {
+                attackSummon.SpecialAttack(plateController.getEnermyPlates(), selectedPlateIndex, selectSpecialAttackIndex); // 적 플레이트에 이로운 효과
+                Debug.Log($"적이 선택한 적의 플레이트 {selectedPlateIndex}가 이로운 효과 대상입니다.");
+            }
+            else
+            {
+                attackSummon.SpecialAttack(plateController.getEnermyPlates(), selectedPlateIndex, selectSpecialAttackIndex); // 적 플레이트에 공격
+                Debug.Log($"적이 선택한 플레이어의 플레이트 {selectedPlateIndex}가 공격 대상입니다.");
+            }
+
         }
     }
 
@@ -152,6 +161,7 @@ public class BattleController : MonoBehaviour
     }
 
 
+    //유효한 플레이트인지 검사
     private bool IsValidPlateIndex(int selectedPlateIndex, int plateCount)
     {
         return selectedPlateIndex >= 0 && selectedPlateIndex < plateCount;

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/StatusEffect.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/StatusEffect.cs
@@ -42,11 +42,12 @@ public class StatusEffect
 
             case StatusType.Poison: // 중독
                 target.ApplyDamage(damagePerTurn); // 즉시 데미지 적용
-                Debug.Log($"{target.getSummonName()}이(가) 중독되었습니다. 매 턴 {damagePerTurn}의 피해를 입을 것입니다.");
+                effectTime -= 1; //데미지를 입히자마자 턴 하나를 줄임.
                 break;
 
             case StatusType.Burn: //화상
                 target.ApplyDamage(damagePerTurn); // 즉시 데미지 적용
+                effectTime -= 1 ; //데미지를 입히자마자 턴 하나를 줄임.
                 break;
 
             case StatusType.LifeDrain: //흡혈

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Enermy.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Enermy.cs
@@ -25,7 +25,7 @@ public class Enermy : Character
         {
             if (enermyPlates[i].getSummon() != null && !enermyPlates[i].getSummon().IsCursed())
             {
-                enermyAttackController.EnermyAttackLogic(enermyPlates[i].getSummon());
+                enermyAttackController.EnermyAttackStart(enermyPlates[i].getSummon());
             }
         }
 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAttackController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAttackController.cs
@@ -7,42 +7,58 @@ public class EnermyAttackController : MonoBehaviour
     [Header("컨트롤러")]
     [SerializeField] private BattleController battleController;
     [SerializeField] private PlateController plateController;
-    private enum AttackType{ NormalAttack, SpecialAttack};
+    private enum AttackType{ NormalAttack, SpecialAttack}; //특수스킬을 사용할지 일반공격을 사용할지를 위한 Enum
     
-    public void EnermyAttackLogic(Summon attakingSummon)
+    public void EnermyAttackStart(Summon attackingSummon)
     {
-        if (attakingSummon == null)
+        if (attackingSummon == null)
         {
             Debug.LogError("공격할 소환수가 없습니다.");
             return;
         }
 
-        if (!attakingSummon.IsCooltime()) //쿨타임중인 스킬이 없을경우
+        for (int i = 0; i < 2; i++) //연속공격 가능성
+        {
+            EnerymyAttackLogic(attackingSummon); //최소1번은 실행
+
+            if (continuesAttackByRank(attackingSummon)) //매개변수로 보낸 소환수의 등급에따라 연속공격이 가능하면 기존 로직 최대 3번 수행
+            {
+                continue; //계속실행
+            }
+            else //연속공격가능성이 false면 바로 종료
+            {
+                return;
+            }
+        }
+    }
+
+    private void EnerymyAttackLogic(Summon attackingSummon)
+    {
+        if (!attackingSummon.IsCooltime()) //쿨타임중인 스킬이 없을경우
         {
             AttackType selectedAttakType = SelectAttackType(); //일반공격과 특수공격을 랜덤으로 받아옴
-            if(selectedAttakType == AttackType.SpecialAttack)
+            if (selectedAttakType == AttackType.SpecialAttack)
             {
-                //쿨타임이 없는 특수스킬을 사용하게 한다. (2개 이상이면 랜덤으로)
-                // 쿨타임이 없는 특수 스킬 목록을 가져옴
-                List<int> availableSpecialAttacks = new List<int>();
+                //쿨타임이 없는 특수스킬을 사용하게 한다.
+                List<int> availableSpecialAttacks = attackingSummon.getAvailableSpecialAttack();  // 쿨타임이 없는 특수 스킬 목록을 가져옴
+                int selectSpecialAttackIndex = getRandomAvilableSpecialAttackIndex(availableSpecialAttacks); //랜덤의 특수스킬 번호를 가져옴
+
+                int selectedPlateIndex = plateController.getClosestPlayerPlatesIndex(); //임시로 가장 가까운적 공격하게 함. 나중에 수정필요
+
+                battleController.SpecialAttackLogic(attackingSummon, selectedPlateIndex, selectSpecialAttackIndex); //특수스킬 사용
             }
             else
             {
-                normalAttackLogic(attakingSummon); //평타
+                enermyNormalAttackLogic(attackingSummon); //평타
             }
         }
         else //스킬들이 쿨타임이여서 평타만 공격
         {
-            normalAttackLogic(attakingSummon);
+            enermyNormalAttackLogic(attackingSummon);
         }
-
-
-
-
-
     }
 
-    private void normalAttackLogic(Summon attackingSummon)
+    private void enermyNormalAttackLogic(Summon attackingSummon)
     {
         int selectAttackIndex = plateController.getClosestPlayerPlatesIndex(); //플레이어 플레이트에서 가장 가까운 소환수의 인덱스를 받아온다.
         if (selectAttackIndex < 0)
@@ -54,7 +70,55 @@ public class EnermyAttackController : MonoBehaviour
     }
 
 
+    
+    //사용가능한 랜덤의 특수스킬 인덱스 받기 ---- 곧 랜덤에서 혼합전략 로직으로 바뀔예정 수정필요
+    private int getRandomAvilableSpecialAttackIndex(List<int> availableSpecialAttacks)
+    {
+        if (availableSpecialAttacks.Count > 0)
+        {
+            int randomIndex = Random.Range(0, availableSpecialAttacks.Count); //사용가능한 특수스킬들중 랜덤값을 받는다.
+            int selectedSpecialAttackIndex = availableSpecialAttacks[randomIndex]; //특수스킬 랜덤 인덱스
+            return selectedSpecialAttackIndex;
+        }
+        return -1;
+    }
 
+
+
+    //등급별 연속공격 가능여부
+    private bool continuesAttackByRank(Summon summon)
+    {
+        float randomValue = Random.Range(0f, 100f); // 0에서 100 사이의 무작위 값
+
+        if(summon.getSummonRank() == SummonRank.Normal) //노말등급은 연속공격 X
+        {
+            return false;
+        }
+        else if(summon.getSummonRank() == SummonRank.Special) //특급은 20%
+        {
+            if (randomValue <= 20) //20%면 연속공격
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else if (summon.getSummonRank() == SummonRank.Boss) //보스 30%
+        {
+            if (randomValue <= 30) //30%면 연속공격
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
 
     //50% 50% 일반공격과 특수공격을 받아온다.
     private AttackType SelectAttackType()

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/TurnController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/TurnController.cs
@@ -27,10 +27,23 @@ public class TurnController : MonoBehaviour
         if (currentTurn == Turn.PlayerTurn)  // 플레이어 턴일 경우
         {
             player.startTurn();
+
+            foreach (var summon in battleController.getEnermySummons()) //플레이어 턴 시작시 적 플레이트의 상태이상 데미지 적용
+            {
+                summon.UpdateStatusEffectsAndCooldowns(); // 상태이상 업데이트
+                summon.getAttackStrategy().ReduceCooldown(); // 일반 공격 쿨타임 감소
+            }
         }
         else if (currentTurn == Turn.EnermyTurn)  // 적의 턴일 경우
         {
             enermy.startTurn();
+
+            // 적 턴 종료 시, 적 소환수의 상태이상 및 쿨타임 업데이트
+            foreach (var summon in battleController.getPlayerSummons())
+            {
+                summon.UpdateStatusEffectsAndCooldowns(); // 상태이상 업데이트
+                summon.getAttackStrategy().ReduceCooldown(); // 일반 공격 쿨타임 감소
+            }
         }
     }
 
@@ -38,13 +51,6 @@ public class TurnController : MonoBehaviour
     {
         if (currentTurn == Turn.PlayerTurn)
         {
-            // 플레이어 턴 종료 시, 플레이어 소환수의 상태이상 및 쿨타임 업데이트
-            foreach (var summon in battleController.getPlayerSummons())
-            {
-                summon.UpdateStatusEffectsAndCooldowns(); // 상태이상 업데이트
-                summon.getAttackStrategy().ReduceCooldown(); // 일반 공격 쿨타임 감소
-            }
-
             // 다음 턴을 적의 턴으로 설정
             currentTurn = Turn.EnermyTurn;
 
@@ -53,12 +59,6 @@ public class TurnController : MonoBehaviour
         }
         else if (currentTurn == Turn.EnermyTurn)
         {
-            // 적 턴 종료 시, 적 소환수의 상태이상 및 쿨타임 업데이트
-            foreach (var summon in battleController.getEnermySummons())
-            {
-                summon.UpdateStatusEffectsAndCooldowns(); // 상태이상 업데이트
-                summon.getAttackStrategy().ReduceCooldown(); // 일반 공격 쿨타임 감소
-            }
 
             // 적 턴이 끝난 후 턴 카운트를 증가시키고 플레이어 턴 시작
             currentTurn = Turn.PlayerTurn;

--- a/Workpiece/Summoner/Assets/Script/Summons/HighDevil.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/HighDevil.cs
@@ -21,7 +21,7 @@ public class HighDevil : Summon
         summonRank = SummonRank.Normal; //일반 적 몬스터
 
         // 일반 공격: 가장 가까운 적 공격
-        attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower,1);
+        attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower,0);
         // 특수 공격: 타겟 지정 공격
         specialAttackStrategies = new IAttackStrategy[] {
             new AttackAllEnemiesStrategy(StatusType.Curse, 140,3), //전체공격 140

--- a/Workpiece/Summoner/Assets/Script/Summons/KingSlime.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/KingSlime.cs
@@ -14,7 +14,7 @@ public class KingSlime : Summon
         summonRank = SummonRank.Special; // 일반 소환수
 
         // 일반 공격: 가장 가까운 적 공격
-        attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 1);
+        attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 0);
         specialAttackStrategies = new IAttackStrategy[] { 
             new AttackAllEnemiesStrategy(StatusType.None, specialPower, 1),//전체공격
             new TargetedAttackStrategy(StatusType.Shield, 80, 2)};//쉴드

--- a/Workpiece/Summoner/Assets/Script/Summons/LowDevil.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/LowDevil.cs
@@ -19,7 +19,7 @@ public class LowDevil : Summon
         summonRank = SummonRank.Normal; //일반 적 몬스터
 
         // 일반 공격: 가장 가까운 적 공격
-        attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower,1);
+        attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower,0);
         // 특수 공격: 타겟 지정 공격
         specialAttackStrategies = new IAttackStrategy[] { new TargetedAttackStrategy(StatusType.Curse, 0 ,2,4) }; //타입, 데미지,적용시간, 쿨타임
     }

--- a/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
@@ -18,7 +18,7 @@ public class Summon : MonoBehaviour
     protected double specialPower;  //특수공격
     protected SummonRank summonRank; //등급
     protected double maxHP; //최대체력
-    protected double nowHP; //현재 체력
+    public double nowHP; //현재 체력
     protected double shield = 0; //쉴드량
     protected bool invincibilityOnce = false;
 
@@ -76,7 +76,7 @@ public class Summon : MonoBehaviour
     // 상태이상 적용 메소드 (여러 상태이상 중복 허용)
     public void ApplyStatusEffect(StatusEffect statusEffect)
     {
-        var existingEffect = activeStatusEffects.FirstOrDefault(e => e.statusType == statusEffect.statusType);
+        var existingEffect = activeStatusEffects.FirstOrDefault(e => e.statusType == statusEffect.statusType); //이미 같은 상태이상이 있는지 가져옴
 
         // 상태이상 타입에 따라 로직을 다르게 처리
         switch (statusEffect.statusType)
@@ -85,15 +85,13 @@ public class Summon : MonoBehaviour
                 if (existingEffect != null)
                 {
                     // 중독 상태가 이미 있으면 지속시간과 피해량을 갱신
-                    existingEffect.effectTime = statusEffect.effectTime;
-                    existingEffect.damagePerTurn = statusEffect.damagePerTurn;
-                    Debug.Log($"{summonName}에게 중복된 중독 상태이상이 갱신되었습니다.");
+                    Debug.Log($"{summonName}은 이미 중독 상태입니다.");
                 }
                 else
                 {
                     // 새로운 중독 상태이상 추가
                     activeStatusEffects.Add(statusEffect);
-                    statusEffect.ApplyStatus(this);  // 즉시 효과 적용
+                    statusEffect.ApplyStatus(this);  // 즉시 효과 적용 //데미지를 받음
                     Debug.Log($"{summonName}에게 중독 상태이상이 적용되었습니다.");
                 }
                 break;
@@ -101,10 +99,7 @@ public class Summon : MonoBehaviour
             case StatusType.Burn:
                 if (existingEffect != null)
                 {
-                    // 화상 상태가 이미 있으면 지속시간과 피해량을 갱신
-                    existingEffect.effectTime = statusEffect.effectTime;
-                    existingEffect.damagePerTurn = statusEffect.damagePerTurn;
-                    Debug.Log($"{summonName}에게 중복된 화상 상태이상이 갱신되었습니다.");
+                    Debug.Log($"{summonName}은 이미 화상 상태입니다.");
                 }
                 else
                 {
@@ -118,9 +113,7 @@ public class Summon : MonoBehaviour
             case StatusType.Upgrade:
                 if (existingEffect != null)
                 {
-                    // 강화 상태가 이미 있으면 지속시간을 갱신하고 효과를 추가 적용
-                    existingEffect.effectTime = statusEffect.effectTime;
-                    Debug.Log($"{summonName}의 공격력 강화 상태가 갱신되었습니다.");
+                    Debug.Log($"{summonName}은 이미 강화 상태입니다.");
                 }
                 else
                 {
@@ -134,9 +127,7 @@ public class Summon : MonoBehaviour
             case StatusType.Curse:
                 if (existingEffect != null)
                 {
-                    // 저주 상태가 이미 있으면 지속시간을 갱신
-                    existingEffect.effectTime = statusEffect.effectTime;
-                    Debug.Log($"{summonName}에게 중복된 저주 상태이상이 갱신되었습니다.");
+                    Debug.Log($"{summonName}은 이미 저주 상태입니다.");
                 }
                 else
                 {
@@ -150,9 +141,7 @@ public class Summon : MonoBehaviour
             case StatusType.Stun:
                 if (existingEffect != null)
                 {
-                    // 스턴 상태가 이미 있으면 지속시간을 갱신
-                    existingEffect.effectTime = statusEffect.effectTime;
-                    Debug.Log($"{summonName}의 스턴 상태가 갱신되었습니다.");
+                    Debug.Log($"{summonName}은 이미 스턴 상태입니다.");
                 }
                 else
                 {
@@ -180,17 +169,22 @@ public class Summon : MonoBehaviour
         {
             if (effect != null)
             {
-                effect.effectTime--; // 상태이상 지속시간 감소
-
-                if (effect.damagePerTurn > 0)
+                if (effect.effectTime > 0) // 상태가 남아있는 동안
                 {
-                    ApplyDamage(effect.damagePerTurn); // 데미지 적용
-                    Debug.Log($"{summonName}이(가) {effect.statusType} 상태로 인해 {effect.damagePerTurn} 데미지를 입습니다.");
-                }
 
-                if (effect.effectTime <= 0)
-                {
-                    expiredEffects.Add(effect); // 지속 시간이 끝난 상태이상은 만료 처리
+                    if (effect.damagePerTurn > 0)
+                    {
+                        ApplyDamage(effect.damagePerTurn); // 지속 데미지 적용
+                        Debug.Log($"{summonName}이(가) {effect.statusType} 상태로 인해 {effect.damagePerTurn} 데미지를 입습니다. 남은 상태이상시간: {effect.effectTime} 턴");
+                    }
+
+                    effect.effectTime--; // 상태이상 지속시간 감소
+
+                    // 상태가 0이 된 후에 만료 리스트에 추가
+                    if (effect.effectTime <= 0)
+                    {
+                        expiredEffects.Add(effect); // 지속 시간이 끝난 상태이상은 만료 처리
+                    }
                 }
             }
         }
@@ -232,7 +226,6 @@ public class Summon : MonoBehaviour
     {
         attackPower *= (1 + multiplier);
         Debug.Log($"{summonName}의 공격력이 {multiplier * 100}% 변경되었습니다. 현재 공격력: {attackPower}");
-
     }
 
     public void ApplyDamage(double damage)
@@ -457,15 +450,17 @@ public class Summon : MonoBehaviour
         return false;
     }
 
-    public List<int> getAvailableSpecialAttackList(Summon summon)
+
+    //사용가능한 
+    public List<int> getAvailableSpecialAttack()
     {
         // 쿨타임이 없는 특수 스킬 목록을 가져옴
         List<int> availableSpecialAttacks = new List<int>();
 
         // 특수 공격 중 쿨타임이 없는 공격을 찾음
-        for (int i = 0; i < summon.getSpecialAttackStrategy().Length; i++)
+        for (int i = 0; i < specialAttackStrategies.Length; i++)
         {
-            var specialAttack = summon.getSpecialAttackStrategy()[i];
+            var specialAttack = specialAttackStrategies[i];
             if (specialAttack != null && specialAttack.getCurrentCooldown() == 0)
             {
                 availableSpecialAttacks.Add(i);


### PR DESCRIPTION
-적 플레이트의 순서대로 공격을 수행한다. 

-적 소환수들은 최소1번 공격하고 등급별로 정해진 확률에 따라 연속공격 가능 여부를 받아와서 연속공격을 할 수 있다.
