### PR TITLE
소환수들의 예측공격 리스트반환

### DIFF
--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/SpecialAttackInfo.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/SpecialAttackInfo.cs
@@ -2,6 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+public enum AttackType
+{
+    NormalAttack, SpecialAttack
+}
 public class SpecialAttackInfo
 {
     private IAttackStrategy attackStrategy;

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackPrediction.cs
@@ -1,0 +1,59 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AttackPrediction
+{
+    private AttackProbability attackProbability;
+    private List<Plate> targetPlate;
+    private int attackPlateIndex;
+    private int specialAttackArrayIndex;
+
+
+
+    public AttackPrediction(List<Plate> targetPlate ,AttackProbability probability, int attackIndex=0, int specialIndex=0)
+    {
+        this.targetPlate = targetPlate;
+        this.attackProbability = probability;
+        this.attackPlateIndex = attackIndex;
+        this.specialAttackArrayIndex = specialIndex;
+    }
+
+
+
+
+    public AttackProbability getAttackProbability()
+    {
+        return attackProbability;
+    }
+
+    public void setAttackProbability(AttackProbability attackProbability)
+    {
+        this.attackProbability = attackProbability;
+    }
+
+
+    public int getAttackPlateIndex()
+    {
+        return attackPlateIndex;
+    }
+
+    public void setAttackPlateIndex(int attackPlateIndex)
+    {
+        this.attackPlateIndex = attackPlateIndex;
+    }
+
+
+    public int getSpecialAttackArrayIndex()
+    {
+        return specialAttackArrayIndex;
+    }
+
+    public void setSpecialAttackArrayIndex(int specialAttackArrayIndex)
+    {
+        this.specialAttackArrayIndex = specialAttackArrayIndex;
+    }
+
+
+
+}

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackPrediction.cs.meta
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackPrediction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a53a49854a4320c4a97f558c05baf938
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAlgorithm.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAlgorithm.cs
@@ -18,39 +18,36 @@ public struct AttackProbability
 
 public class EnermyAlgorithm : MonoBehaviour
 {
-    private PlateController plateController;
-    private List<Plate> playerPlates;
-    private PlayerAttackPrediction playerAttackPrediction;
-    Dictionary<int, AttackProbability> attackProbabilityMap = new Dictionary<int, AttackProbability>();
+    [SerializeField] private PlateController plateController;
+    [SerializeField] private PlayerAttackPrediction playerAttackPrediction;
+     private List<AttackPrediction> playerAttackPredictionsList;
 
-    private void Awake()
-    {
-        plateController = GetComponent<PlateController>();
-        playerAttackPrediction = GetComponent<PlayerAttackPrediction>();
-    }
 
     // 알고리즘 순서대로 실행
     public void ExecuteEnermyAlgorithm(Summon attackingSummon, int targetIndex)
     {
-       
+
         // 1. 소환수의 상태 체크
-        playerPlates = CheckPlayerPlateState(); // 현재 playerPlates들
+        List<Plate> playerPlates = CheckPlayerPlateState(); // 현재 playerPlates들
 
         // 2. 몬스터의 상태 체크 (새 리스트에 상태 조정된 enermyPlates 추가)
         List<Plate> applyEnermyPlates = GetApplyStatusEnermyPlates();
 
-        for (int i = 0; i < playerPlates.Count; i++) //플레이어 플레이트 수만큼 검사
-        {
-            // 3. 소환수의 공격 예측 알고리즘 실행 (특수공격 확률을 받음)
-            AttackProbability defaultProbability = new AttackProbability(0.5f, 0.5f); //기본 50% 50%
-            attackProbabilityMap[targetIndex] = defaultProbability; //플레이어 플레이트의 인덱스와 키값을 일치하도록
+        //3. 소환수의 예측공격 리스트를 받아온다.
+        playerAttackPredictionsList = playerAttackPrediction.getPlayerAttackPredictionList(playerPlates, applyEnermyPlates);
 
-            // 3.2 PlayerAttackPrediction 클래스에서 재계산된 값을 가져와서 업데이트
-            //AttackProbability recalculatedProbability = playerAttackPrediction.ExecutePlayerAttackPrediction(playerPlates, applyEnermyPlates, defaultProbability);
-            //attackProbabilityMap[targetIndex] = recalculatedProbability;
-        }
         // 4. 몬스터의 공격 알고리즘 실행
+        //추후 추가예정
     }
+
+
+
+
+
+
+
+
+
 
     // 1. 현재 playerPlate들을 공격이나 데미지 적용이 안되게 새 리스트로 가져온다.
     public List<Plate> CheckPlayerPlateState()

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAttackController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAttackController.cs
@@ -50,41 +50,39 @@ public class EnermyAttackController : MonoBehaviour
         }
     }
 
-
-    //기존 코드
-    //private void EnerymyAttackLogic(Summon attackingSummon, Summon target, int targetIndex)
-    //{
-    //    if (!attackingSummon.IsCooltime()) //쿨타임중인 스킬이 없을경우
-    //    {
-    //        AttackType selectedAttakType = SelectAttackType(); //일반공격과 특수공격을 랜덤으로 받아옴
-    //        if (selectedAttakType == AttackType.SpecialAttack)
-    //        {
-    //            //쿨타임이 없는 특수스킬을 사용하게 한다.
-    //            List<int> availableSpecialAttacks = attackingSummon.getAvailableSpecialAttack();  // 쿨타임이 없는 특수 스킬 목록을 가져옴
-
-
-    //            int selectSpecialAttackIndex = getRandomAvilableSpecialAttackIndex(availableSpecialAttacks); //랜덤의 특수스킬 번호를 가져옴
-    //            int selectedPlateIndex = plateController.getClosestPlayerPlatesIndex(attackingSummon); //임시로 가장 가까운적 공격하게 함. 나중에 수정필요
-    //            algorithm.ExecuteEnermyAlgorithm(attackingSummon, targetIndex); //알고리즘 실행
-
-    //            battleController.SpecialAttackLogic(attackingSummon, selectedPlateIndex, selectSpecialAttackIndex); //특수스킬 사용
-    //        }
-    //        else
-    //        {
-    //            enermyNormalAttackLogic(attackingSummon); //평타
-    //        }
-    //    }
-    //    else //스킬들이 쿨타임이여서 평타만 공격
-    //    {
-    //        enermyNormalAttackLogic(attackingSummon);
-    //    }
-    //}
-
     private void EnerymyAttackLogic(Summon attackingSummon, Summon target, int targetIndex)
     {
+        if (!attackingSummon.IsCooltime()) //쿨타임중인 스킬이 없을경우
+        {
+            AttackType selectedAttakType = SelectAttackType(); //일반공격과 특수공격을 랜덤으로 받아옴
+            if (selectedAttakType == AttackType.SpecialAttack)
+            {
+                //쿨타임이 없는 특수스킬을 사용하게 한다.
+                List<int> availableSpecialAttacks = attackingSummon.getAvailableSpecialAttack();  // 쿨타임이 없는 특수 스킬 목록을 가져옴
 
 
-    }
+                int selectSpecialAttackIndex = getRandomAvilableSpecialAttackIndex(availableSpecialAttacks); //랜덤의 특수스킬 번호를 가져옴
+                int selectedPlateIndex = plateController.getClosestPlayerPlatesIndex(attackingSummon); //임시로 가장 가까운적 공격하게 함. 나중에 수정필요
+                algorithm.ExecuteEnermyAlgorithm(attackingSummon, targetIndex); //알고리즘 실행
+
+                battleController.SpecialAttackLogic(attackingSummon, selectedPlateIndex, selectSpecialAttackIndex); //특수스킬 사용
+            }
+            else
+            {
+                enermyNormalAttackLogic(attackingSummon); //평타
+            }
+        }
+        else //스킬들이 쿨타임이여서 평타만 공격
+        {
+            enermyNormalAttackLogic(attackingSummon);
+        }
+    }   
+
+    //private void EnerymyAttackLogic(Summon attackingSummon, Summon target, int targetIndex)
+    //{
+
+
+    //}
 
 
     //일반 공격

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/PlateController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/PlateController.cs
@@ -267,6 +267,19 @@ public class PlateController : MonoBehaviour
         return -1; // 공격할 소환수가 없으면 -1 반환
     }
 
+    public int getClosestEnermyPlatesIndex(Summon attackingSummon) //플레이어 플레이트중 가장 가까이 있는 소환수의 인덱스를 반환
+    {
+        for (int i = 0; i < playerPlates.Count; i++)
+        {
+            Summon currentSummon = playerPlates[i].getCurrentSummon();
+            if (currentSummon != null && currentSummon != attackingSummon) // 현재 소환수가 존재하고, 공격하는 소환수와 같지 않은 경우
+            {
+                return i;
+            }
+        }
+
+        return -1; // 공격할 소환수가 없으면 -1 반환
+    }
 
 
 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/PlayerAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/PlayerAttackPrediction.cs
@@ -6,75 +6,429 @@ public class PlayerAttackPrediction : MonoBehaviour
 {
     private PlateController plateController;
 
-    public AttackProbability catAttackProbability(List<Plate> playerSummons, List<Plate> enermySummons, AttackProbability attackProbability)
+
+    private CatAttackPrediction catAttackPrediction;
+    private FoxAttackPrediction foxAttackPrediction;
+    private WolfAttackPrediction wolfAttackPrediction;
+    private EagleAttackPrediction eagleAttackPrediction;
+    private SnakeAttackPrediction snakeAttackPrediction;
+    private RabbitAttackPrediction rabbitAttackPrediction;
+    private void Awake()
     {
-        AttackProbability recalculatedProbability = attackProbability; // 기본 50% 50%
+        plateController = GetComponent<PlateController>();
+        catAttackPrediction = GetComponent<CatAttackPrediction>();
+        foxAttackPrediction = GetComponent<FoxAttackPrediction>();
+        wolfAttackPrediction = GetComponent<WolfAttackPrediction>();
+        eagleAttackPrediction = GetComponent<EagleAttackPrediction>();
+        snakeAttackPrediction = GetComponent<SnakeAttackPrediction>();
+        rabbitAttackPrediction = GetComponent<RabbitAttackPrediction>();
+    }
 
-        // 1. 일반 공격 시 몬스터를 물리칠 수 있는지 여부를 판단
-        if (CanDefeatWithNormalAttack(playerSummons, enermySummons))
-        {
-            recalculatedProbability.normalAttackProbability += 0.1f; // 일반 공격 확률 +10%
-        }
+    public List<AttackPrediction> getPlayerAttackPredictionList(List<Plate>playerPlates, List<Plate>enermyPlates) //플레이어의 행동예측 반환
+    {
+        List<AttackPrediction> playerPrediction = new List<AttackPrediction>();
 
-        // 2. 각 소환수의 특수 공격 전략을 순회하여 조건을 체크
-        foreach (Plate plate in playerSummons)
+        foreach (Plate plate in playerPlates)
         {
             Summon summon = plate.getCurrentSummon();
+
             if (summon != null)
             {
-                IAttackStrategy[] specialAttackStrategies = summon.getAvailableSpecialAttacks(); //사용가능한 스킬들을 반환
+                // 소환수의 특수 스킬이 사용 가능한지 확인
+                IAttackStrategy[] availableSpecialAttacks = summon.getAvailableSpecialAttacks();
+                bool hasUsableSpecialAttack = (availableSpecialAttacks != null && availableSpecialAttacks.Length > 0);
 
-                foreach (IAttackStrategy specialAttack in specialAttackStrategies)
+                // 특수 스킬이 없는 경우 일반 공격으로 예측
+                if (!hasUsableSpecialAttack)
                 {
-                    if (CanDefeatWithSpecialAttack(specialAttack, enermySummons))
+                    Debug.Log($"{summon.getSummonName()}는 사용 가능한 특수 스킬이 없습니다. 일반 공격으로 처리.");
+                    AttackProbability attackProbability = new AttackProbability(100f, 0f); //일반공격을 100%
+                    int attackIndex = plateController.getClosestEnermyPlatesIndex(summon);
+                    if(attackIndex == -1)
                     {
-                        recalculatedProbability.specialAttackProbability += 0.1f; // 특수 공격 확률 +10%
+                        Debug.Log("공격할 인덱스가 없음");
+                    }
+                    AttackPrediction attackPrediction = new AttackPrediction(enermyPlates, attackProbability, attackIndex);
+             
+                    playerPrediction.Add(attackPrediction);
+                }
+                else
+                {
+                    // 소환수에 따라 예측공격 수행
+                    switch (summon.getSummonType())
+                    {
+                        case SummonType.Cat:
+                            AttackPrediction catPrediction = getCatAttackPrediction(summon, enermyPlates);
+                            if (catPrediction != null)
+                            {
+                                playerPrediction.Add(catPrediction);
+                            }
+                            break;
+                        case SummonType.Wolf:
+                            AttackPrediction wolfPrediction = getWolfAttackPrediction(summon, enermyPlates);
+                            if (wolfPrediction != null)
+                            {
+                                playerPrediction.Add(wolfPrediction);
+                            }
+                            break;
+                        case SummonType.Snake:
+                            AttackPrediction snakePrediction = getSnakeAttackPrediction(summon, enermyPlates);
+                            if (snakePrediction != null)
+                            {
+                                playerPrediction.Add(snakePrediction);
+                            }
+                            break;
+
+                        case SummonType.Rabbit:
+                            AttackPrediction rabitPrediction = getRabbitAttackPrediction(summon, playerPlates, enermyPlates);
+                            if (rabitPrediction != null)
+                            {
+                                playerPrediction.Add(rabitPrediction);
+                            }
+                            break;
+
+                        case SummonType.Eagle:
+                            AttackPrediction eaglePrediction = getEagleAttackPrediction(summon, enermyPlates);
+                            if (eaglePrediction != null)
+                            {
+                                playerPrediction.Add(eaglePrediction);
+                            }
+                            break;
+
+                        case SummonType.Fox:
+                            AttackPrediction foxPrediction = getFoxAttackPrediction(summon, playerPlates, enermyPlates);
+                            if (foxPrediction != null)
+                            {
+                                playerPrediction.Add(foxPrediction);
+                            }
+                            break;
                     }
                 }
             }
         }
 
-        // 3. 피해를 많이 줄 수 있는 공격에 추가적인 확률을 부여
-        if (recalculatedProbability.normalAttackProbability > recalculatedProbability.specialAttackProbability)
+        return playerPrediction;
+    }
+
+
+    //고양이 예측공격
+    private AttackPrediction getCatAttackPrediction(Summon cat, List<Plate> enermyPlates)
+    {
+        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
+        AttackProbability attackProbability = new AttackProbability(50f, 50f);
+        int attackIndex = catAttackPrediction.getClosestEnermyIndex(enermyPlates);
+
+
+        // 일반 공격으로 처치가 가능하면 일반 공격 확률 10% 증가
+        if (catAttackPrediction.getIndexofNormalAttackCanKill(cat, enermyPlates) != -1)
         {
-            recalculatedProbability.normalAttackProbability += 0.05f; // 일반 공격 확률 +5%
+            attackProbability = AdjustAttackProbabilities(attackProbability, 0.1f, true);
+            attackIndex = catAttackPrediction.getIndexofNormalAttackCanKill(cat, enermyPlates); //일반 공격으로 처치가능한 인덱스 받기
         }
         else
         {
-            recalculatedProbability.specialAttackProbability += 0.05f; // 특수 공격 확률 +5%
-        }
-
-        return recalculatedProbability;
-    }
-
-    // 일반 공격으로 적을 물리칠 수 있는지 여부를 판단하는 메서드
-    private bool CanDefeatWithNormalAttack(List<Plate> playerSummons, List<Plate> enermySummons)
-    {
-        // 일반 공격으로 적 소환수를 물리칠 수 있는지 확인하는 로직 추가
-        // 예시 로직: 가장 가까운 적 소환수를 타겟으로
-        foreach (Plate enermyPlate in enermySummons)
-        {
-            Summon enermySummon = enermyPlate.getCurrentSummon();
-            if (enermySummon != null && enermySummon.getNowHP() < 50) // 임의의 조건 예시
+            // 특수 공격으로 처치가 가능하면 특수 공격 확률 증가
+            if (catAttackPrediction.getIndexofSpecialCanKill(cat, enermyPlates) != -1)
             {
-                return true;
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+                attackIndex = catAttackPrediction.getIndexofSpecialCanKill(cat, enermyPlates); //특수 공격으로 처치가능한 인덱스 받기
+            }
+            else
+            { //특수공격에 +5%
+                attackProbability = AdjustAttackProbabilities(attackProbability, 5f, false);
+                attackIndex = catAttackPrediction.getClosestEnermyIndex(enermyPlates); //적 플레이트 중에서 가장 가까이 있는 인덱스 받기
             }
         }
-        return false;
+
+        AttackPrediction attackPrediction = new AttackPrediction(enermyPlates, attackProbability, attackIndex);
+        return attackPrediction;
     }
 
-    // 특정 특수 공격 전략으로 적을 물리칠 수 있는지 여부를 판단하는 메서드
-    private bool CanDefeatWithSpecialAttack(IAttackStrategy specialAttack, List<Plate> enermySummons)
+    //늑대의 예측공격
+    private AttackPrediction getWolfAttackPrediction(Summon wolf, List<Plate> enermyPlates)
     {
-        // 특수 공격으로 적 소환수를 물리칠 수 있는지 확인하는 로직 추가
-        foreach (Plate enermyPlate in enermySummons)
+        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
+        AttackProbability attackProbability = new AttackProbability(50f, 50f);
+        int attackIndex = wolfAttackPrediction.getClosestEnermyIndex(enermyPlates);
+
+        if (wolfAttackPrediction.IsEnermyCountTwoOrMore(enermyPlates)) //적이 2마리 이상인가?
         {
-            Summon enermySummon = enermyPlate.getCurrentSummon();
-            //if (enermySummon != null && specialAttack.getCalculateDamage() > enermySummon.getNowHP()) // 특수 공격이 적 체력보다 큰지 확인
-            //{
-            //    return true;
-            //}
+            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+            if (wolfAttackPrediction.AllEnermyHealthOver50(enermyPlates)) //몬스터 체력이 모두 50% 이상인가?
+            {
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+            }
+            else if(wolfAttackPrediction.AllEnermyHealthDown50(enermyPlates)) //몬스터 체력이 모두 50% 이하인가?
+            {
+                if (wolfAttackPrediction.HasSpecificAvailableSpecialAttack(wolf, enermyPlates))
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+                }
+            }
+            else if (wolfAttackPrediction.IsEnermyHealthDifferenceOver30(enermyPlates)) //몬스터 한쪽이 다른 쪽에비해 체력이 30% 높은가?
+            {
+                if (wolfAttackPrediction.IsLowestHealthEnermyClosest(wolf, enermyPlates)) //낮은쪽의 인덱스가 근접공격하는 인덱스와 동일한가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 20f, true);
+                }
+                else
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+                }
+            }
         }
-        return false;
+        else if(wolfAttackPrediction.IsEnermyCountOne(enermyPlates)) //적이 1마리 인가?
+        {
+            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+            
+            if(wolfAttackPrediction.getIndexofNormalAttackCanKill(wolf,enermyPlates) != -1) //일반 공격으로 몬스터를 물리칠 수 있는가?
+            {
+                attackIndex = wolfAttackPrediction.getIndexofNormalAttackCanKill(wolf, enermyPlates);
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+            }
+            else
+            {
+                //일반 공격과 특수공격중 피해를 더 줄 수 있는 공격을 반환했을 때 일반 공격일경우
+                if (wolfAttackPrediction.getMostDamageAttack(wolf, enermyPlates) == AttackType.NormalAttack)
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, true);
+                }
+                else
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, false);
+                }
+            }
+        }
+        else
+        {
+            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+        }
+
+        AttackPrediction attackPrediction = new AttackPrediction(enermyPlates, attackProbability, attackIndex);
+        return attackPrediction;
     }
+
+
+    //토끼의 예측공격
+    private AttackPrediction getRabbitAttackPrediction(Summon rabbit, List<Plate> playerPlates, List<Plate> enermyPlates)
+    {
+        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
+        AttackProbability attackProbability = new AttackProbability(50f, 50f);
+        int attackIndex = rabbitAttackPrediction.getClosestEnermyIndex(enermyPlates);
+        AttackPrediction attackPrediction = new AttackPrediction(enermyPlates, attackProbability, attackIndex); //기본은 가장 가까운적 공격
+
+        if (rabbitAttackPrediction.GetIndexOfLowerHealthIfDifferenceOver30(playerPlates) != -1) //소환수 중 한쪽이 다른 쪽과 체력을 비교했을 때 30% 이상 낮은가?
+        {
+            attackIndex = rabbitAttackPrediction.GetIndexOfLowerHealthIfDifferenceOver30(playerPlates);
+            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+            attackPrediction = new AttackPrediction(playerPlates, attackProbability, attackIndex);
+        }
+        else if (rabbitAttackPrediction.getIndexOfLowerHealthIfAllDown30(playerPlates) != -1) //소환수 모두의 체력이 30% 이하인가?
+        {
+            attackIndex = rabbitAttackPrediction.getIndexOfLowerHealthIfAllDown30(playerPlates);
+            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+            attackPrediction = new AttackPrediction(playerPlates, attackProbability, attackIndex);
+        }
+        else if (rabbitAttackPrediction.AllPlayerSummonOver70Percent(playerPlates))
+        {
+            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+            attackPrediction = new AttackPrediction(enermyPlates, attackProbability, attackIndex);
+        }
+        else if (rabbitAttackPrediction.CanNormalAttackKill(rabbit, enermyPlates))
+        {
+            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+            attackPrediction = new AttackPrediction(enermyPlates, attackProbability, attackIndex);
+        }
+
+
+        return attackPrediction;
+    }
+
+
+    //뱀 예측공격
+    private AttackPrediction getSnakeAttackPrediction(Summon snake, List<Plate> enermyPlates)
+    {
+        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
+        AttackProbability attackProbability = new AttackProbability(50f, 50f);
+        int attackIndex = snakeAttackPrediction.getClosestEnermyIndex(enermyPlates);
+
+
+        if (snakeAttackPrediction.IsEnermyAlreadyPoisoned(enermyPlates)){ //몬스터들이 이미 중독 상태인가?
+            attackProbability = new AttackProbability(100f, 0f);
+        }
+        else if(!snakeAttackPrediction.canUseSpecialAttack(snake)) //특수공격을 사용할 수 있는가?
+        {
+            attackProbability = new AttackProbability(100f, 0f);
+        }
+        else
+        {
+            if (snakeAttackPrediction.isEnermyCountOverTwo(enermyPlates)) //적이 2마리 이상인가?
+            {
+                if (snakeAttackPrediction.AllEnermyHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+                }
+                else
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+                }
+                if (snakeAttackPrediction.hasMonsterWithMoreThan4Attacks(enermyPlates)) //몬스터 중 공격의 개수가 4개 이상인 몹이 존재하는가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+                }
+            }
+            else //1마리 일때
+            {
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+                if (snakeAttackPrediction.AllEnermyHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+                }
+                if (snakeAttackPrediction.CanNormalAttackKill(snake, enermyPlates)) //일반 공격 시 몬스터를 물리칠 수 있는가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+                }
+            }
+        }
+
+        AttackPrediction attackPrediction = new AttackPrediction(enermyPlates, attackProbability, attackIndex);
+        return attackPrediction;
+    }
+
+    //여우 예측공격
+    private AttackPrediction getFoxAttackPrediction(Summon fox, List<Plate> playerPlates, List<Plate> enermyPlates)
+    {
+        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
+        AttackProbability attackProbability = new AttackProbability(50f, 50f);
+        int attackIndex = foxAttackPrediction.getClosestEnermyIndex(enermyPlates);
+        List<Plate> targetPlate = enermyPlates;
+
+
+        if (foxAttackPrediction.isAnySummonWithCurseStatus(playerPlates)) //소환수중 저주상태에 걸려있는 몹이 있는가?
+        {
+            attackProbability = new AttackProbability(0f, 100f); //특수공격 100%
+            targetPlate = playerPlates;
+        }
+        else if(foxAttackPrediction.isTwoOrMoreEnemies(enermyPlates)) //적이 2마리 이상 존재하는가?
+        {
+            if (foxAttackPrediction.AllEnemiesHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
+            {
+                if (foxAttackPrediction.AllSummonsLowOrMediumRank(playerPlates)) //아군의 등급이 모두 하급과 중급인가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+                    targetPlate = playerPlates;
+                }
+            }
+            else if (foxAttackPrediction.isAnyEnemyHealthDown30Percent(enermyPlates)) //적의 체력이 하나만 30% 아래인가
+            {
+                if (foxAttackPrediction.CanNormalAttackKill(fox, enermyPlates)) //일반공격시 처치할 수 있는가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+                }
+            }
+        }
+        else if(foxAttackPrediction.isOnlyOneEnemy(enermyPlates)) //적이 1마리 인가?
+        {
+            if (foxAttackPrediction.isAnyEnemyHealthOver70Percent(enermyPlates)) //적의 체력이 70% 이상인가?
+            {
+                if (foxAttackPrediction.AllSummonsLowOrMediumRank(playerPlates)) //아군의 등급이 모두 하급과 중급인가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+                    targetPlate = playerPlates;
+                }
+            }
+            else if(foxAttackPrediction.CanNormalAttackKill(fox, enermyPlates)) //일반공격시 몬스터를 물리칠 수 있는가?
+            {
+                if (foxAttackPrediction.CanNormalAttackKill(fox, enermyPlates)) //일반공격시 처치할 수 있는가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+                }
+            }
+        }
+
+        AttackPrediction attackPrediction = new AttackPrediction(targetPlate, attackProbability, attackIndex);
+        return attackPrediction;
+    }
+
+
+    //독수리 예측공격
+    private AttackPrediction getEagleAttackPrediction(Summon eagle, List<Plate> enermyPlates)
+    {
+        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
+        AttackProbability attackProbability = new AttackProbability(50f, 50f);
+        int attackIndex = eagleAttackPrediction.getClosestEnermyIndex(enermyPlates); //가장 가까운적의 인덱스 기본값
+
+
+        if (eagleAttackPrediction.isTwoOrMoreEnemies(enermyPlates)) //적이 2마리 이상인가?
+        {
+            if (eagleAttackPrediction.isEnermyHealthDifferenceOver30(enermyPlates)) //몬스터 한 쪽이 다른쪽과 비교했을 때 30% 이상 낮은가?
+            {
+                if (eagleAttackPrediction.getNormalAttackKillIndex(eagle, enermyPlates) != -1) //일반 공격으로 체력이 낮은 쪽을 공격할 수 있는가?
+                {
+                    attackIndex = eagleAttackPrediction.getNormalAttackKillIndex(eagle, enermyPlates);
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+                }
+                else
+                {
+                    attackIndex = eagleAttackPrediction.getSpecialAttackKillIndex(eagle, enermyPlates);
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+                }
+            }
+            else if (eagleAttackPrediction.AreEnermyHealthWithin10Percent(enermyPlates)) //몬스터의 체력이 서로 비슷한가?
+            {
+                if (eagleAttackPrediction.getIndexOfMostHealthEnermy(enermyPlates) != -1) //가장 체력이 많은 몬스터의 인덱스
+                {
+                    attackIndex = eagleAttackPrediction.getIndexOfMostHealthEnermy(enermyPlates);
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+                }
+            }
+        }
+        else if (eagleAttackPrediction.isOnlyOneEnemy(enermyPlates)) //적이 1마리 인가?
+        {
+            if (eagleAttackPrediction.getNormalAttackKillIndex(eagle, enermyPlates) != -1)
+            {
+                attackIndex = eagleAttackPrediction.getNormalAttackKillIndex(eagle, enermyPlates);
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true);
+            }
+            else if (eagleAttackPrediction.getSpecialAttackKillIndex(eagle, enermyPlates) != -1)
+            {
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false);
+            }
+            else
+            {
+                if(eagleAttackPrediction.getTypeOfMoreAttackDamage(eagle,enermyPlates) == AttackType.NormalAttack)//일반공격과 특수공격 중 피해를 많이 줄 공격에 5%상승
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, true);
+                }
+                else
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, false);
+                }
+            }
+        }
+
+        AttackPrediction attackPrediction = new AttackPrediction(enermyPlates, attackProbability, attackIndex);
+        return attackPrediction;
+    }
+
+
+        // 확률 값을 설정하고 조정하여 반환하는 메소드
+        public AttackProbability AdjustAttackProbabilities(AttackProbability currentProbabilities, float AttackChange, bool isNormalAttack)
+    {
+        if (isNormalAttack)
+        {
+            // 일반 공격 확률을 증가시키고, 특수 공격 확률을 그만큼 감소
+            currentProbabilities.normalAttackProbability += AttackChange;
+            currentProbabilities.specialAttackProbability -= AttackChange;
+        }
+        else
+        {
+            // 또는, 특수 공격 확률을 증가시키고, 일반 공격 확률을 그만큼 감소
+            currentProbabilities.specialAttackProbability += AttackChange;
+            currentProbabilities.normalAttackProbability -= AttackChange;
+        }
+        return currentProbabilities;
+    }
+
+
 }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction.meta
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27698a454a685ac469484da9be0fd825
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CatAttackPrediction : MonoBehaviour
+{
+    private PlateController plateController;
+    private void Awake()
+    {
+        plateController = GetComponent<PlateController>();
+    }
+
+
+    // 일반 공격으로 적을 물리칠 수 있는 가장 가까운 인덱스를 반환하는 메소드
+    public int getIndexofNormalAttackCanKill(Summon attackingSummon, List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null && attackingSummon.getAttackPower() >= enermySummon.getNowHP())
+            {
+                // 일반 공격으로 적의 체력을 0 이하로 만들 수 있으면 해당 인덱스 반환
+                return i;
+            }
+        }
+        return -1; // 공격 가능한 적이 없으면 -1 반환
+    }
+
+    //특수스킬로 죽일 수 있는 인덱스 반환
+    public int getIndexofSpecialCanKill(Summon attackingSummon, List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null && attackingSummon.getAttackPower() >= enermySummon.getNowHP())
+            {
+                // 일반 공격으로 적의 체력을 0 이하로 만들 수 있으면 해당 인덱스 반환
+                return i;
+            }
+        }
+        return -1; // 공격 가능한 적이 없으면 -1 반환
+    }
+
+
+    public int getClosestEnermyIndex(List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null)
+            {
+                return i; // 가장 가까운(첫 번째로 발견된) 적 소환수의 인덱스 반환
+            }
+        }
+        return -1; // 적 소환수가 없으면 -1 반환
+    }
+
+}

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs.meta
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f43ba149b0784942a9fa334d497d6fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/EagleAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/EagleAttackPrediction.cs
@@ -1,0 +1,186 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EagleAttackPrediction : MonoBehaviour
+{
+
+    private PlateController plateController;
+
+    private void Awake()
+    {
+        plateController = GetComponent<PlateController>();
+    }
+
+
+    // 적이 2마리 이상인가?
+    public bool isTwoOrMoreEnemies(List<Plate> enermyPlates)
+    {
+        int count = 0;
+        foreach (Plate plate in enermyPlates)
+        {
+            if (plate.getCurrentSummon() != null) count++;
+        }
+        return count >= 2;
+    }
+
+    // 적이 1마리인가?
+    public bool isOnlyOneEnemy(List<Plate> enermyPlates)
+    {
+        int count = 0;
+        foreach (Plate plate in enermyPlates)
+        {
+            if (plate.getCurrentSummon() != null) count++;
+        }
+        return count == 1;
+    }
+
+
+    // 몬스터의 한쪽이 다른 쪽의 체력을 비교했을 때 30% 이상 낮은가?
+    public bool isEnermyHealthDifferenceOver30(List<Plate> enermyPlates)
+    {
+        if (enermyPlates.Count < 2) return false;
+
+        double maxHealthRatio = double.MinValue;
+        double minHealthRatio = double.MaxValue;
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null)
+            {
+                double healthRatio = enermySummon.getNowHP() / enermySummon.getMaxHP();
+                if (healthRatio > maxHealthRatio) maxHealthRatio = healthRatio;
+                if (healthRatio < minHealthRatio) minHealthRatio = healthRatio;
+            }
+        }
+
+        return (maxHealthRatio - minHealthRatio) > 0.3f;
+    }
+
+    // 몬스터들의 체력이 서로 10% 이내 차이인지 검사하는 메소드
+    public bool AreEnermyHealthWithin10Percent(List<Plate> enermyPlates)
+    {
+        double minHealthRatio = double.MaxValue;
+        double maxHealthRatio = double.MinValue;
+
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null)
+            {
+                // 현재 체력 비율을 계산
+                double healthRatio = enermySummon.getNowHP() / enermySummon.getMaxHP();
+
+                // 최소 및 최대 체력 비율 업데이트
+                if (healthRatio < minHealthRatio) minHealthRatio = healthRatio;
+                if (healthRatio > maxHealthRatio) maxHealthRatio = healthRatio;
+            }
+        }
+
+        // 최대와 최소 체력 비율의 차이가 10% 이내인지 검사
+        return (maxHealthRatio - minHealthRatio) <= 0.1;
+    }
+
+
+    // 가장 체력이 많은 몬스터의 인덱스를 반환하는 메소드
+    public int getIndexOfMostHealthEnermy(List<Plate> enermyPlates)
+    {
+        int maxHealthIndex = -1;
+        double maxHealth = double.MinValue;
+
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null)
+            {
+                double currentHealth = enermySummon.getNowHP();
+                if (currentHealth > maxHealth)
+                {
+                    maxHealth = currentHealth;
+                    maxHealthIndex = i; // 현재 최대 체력인 소환수의 인덱스 저장
+                }
+            }
+        }
+
+        return maxHealthIndex; // 가장 체력이 높은 소환수의 인덱스 반환, 없으면 -1
+    }
+
+    public AttackType getTypeOfMoreAttackDamage(Summon eagle, List<Plate> enermyPlates)
+    {
+        double maxDamage = eagle.getAttackPower(); // 기본값: 일반 공격의 데미지
+
+        // 사용 가능한 특수 공격 목록 가져오기
+        IAttackStrategy[] availableSpecialAttacks = eagle.getAvailableSpecialAttacks();
+
+        // 각 특수 공격 확인
+        foreach (IAttackStrategy specialAttack in availableSpecialAttacks)
+        {
+            double totalSpecialAttackDamage = 0;
+
+            // 적 플레이트에 있는 모든 소환수에게 특수 공격 시 예상 피해 축적
+            foreach (Plate plate in enermyPlates)
+            {
+                Summon enermySummon = plate.getCurrentSummon();
+                if (enermySummon != null)
+                {
+                    totalSpecialAttackDamage += specialAttack.getSpecialDamage();
+                }
+            }
+
+            // 특수 공격으로 총 피해가 일반 공격보다 크다면 업데이트
+            if (totalSpecialAttackDamage > maxDamage)
+            {
+                maxDamage = totalSpecialAttackDamage;
+                return AttackType.SpecialAttack;
+            }
+        }
+
+        return AttackType.NormalAttack;
+    }
+
+
+    // 특수 공격으로 공격할 수 있는지 확인하고, 공격 가능한 인덱스를 반환하는 메소드
+    public int getSpecialAttackKillIndex(Summon eagle, List<Plate> enermyPlates)
+    {
+        foreach (IAttackStrategy specialAttack in eagle.getAvailableSpecialAttacks())
+        {
+            for (int i = 0; i < enermyPlates.Count; i++)
+            {
+                Summon enermySummon = enermyPlates[i].getCurrentSummon();
+                if (enermySummon != null && specialAttack.getSpecialDamage() >= enermySummon.getNowHP())
+                {
+                    return i; // 특수 공격으로 처치 가능한 인덱스 반환
+                }
+            }
+        }
+        return -1; // 처치할 수 없으면 -1 반환
+    }
+
+    // 가장 가까운 적을 공격했을 때 물리칠 수 있는지 확인하고, 공격 가능한 인덱스를 반환하는 메소드
+    public int getNormalAttackKillIndex(Summon eagle, List<Plate> enermyPlates)
+    {
+        int closestIndex = getClosestEnermyIndex(enermyPlates);
+        if (closestIndex != -1)
+        {
+            Summon closestEnermySummon = enermyPlates[closestIndex].getCurrentSummon();
+            if (closestEnermySummon != null && eagle.getAttackPower() >= closestEnermySummon.getNowHP())
+            {
+                return closestIndex; // 가장 가까운 적을 일반 공격으로 처치할 수 있는 인덱스 반환
+            }
+        }
+        return -1; // 처치할 수 없으면 -1 반환
+    }
+
+    public int getClosestEnermyIndex(List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null)
+            {
+                return i; // 가장 가까운(첫 번째로 발견된) 적 소환수의 인덱스 반환
+            }
+        }
+        return -1; // 적 소환수가 없으면 -1 반환
+    }
+}

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/EagleAttackPrediction.cs.meta
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/EagleAttackPrediction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fcb56653b5fa2e4f8efb66dfd65b205
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/FoxAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/FoxAttackPrediction.cs
@@ -1,0 +1,136 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FoxAttackPrediction : MonoBehaviour
+{
+    private PlateController plateController;
+
+    private void Awake()
+    {
+        plateController = GetComponent<PlateController>();
+    }
+
+    // 소환수 중 저주 상태 이상에 걸려있는 몹이 존재하는가?
+    public bool isAnySummonWithCurseStatus(List<Plate> playerPlates)
+    {
+        foreach (Plate plate in playerPlates)
+        {
+            Summon playerSummon = plate.getCurrentSummon();
+            if (playerSummon != null && playerSummon.IsCursed())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // 적이 2마리 이상인가?
+    public bool isTwoOrMoreEnemies(List<Plate> enermyPlates)
+    {
+        int count = 0;
+        foreach (Plate plate in enermyPlates)
+        {
+            if (plate.getCurrentSummon() != null) count++;
+        }
+        return count >= 2;
+    }
+
+
+    // 적이 1마리인가?
+    public bool isOnlyOneEnemy(List<Plate> enermyPlates)
+    {
+        int count = 0;
+        foreach (Plate plate in enermyPlates)
+        {
+            if (plate.getCurrentSummon() != null) count++;
+        }
+        return count == 1;
+    }
+
+    // 적의 체력이 모두 50% 이상인가?
+    public bool AllEnemiesHealthOver50(List<Plate> enermyPlates)
+    {
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null && enermySummon.getNowHP() / enermySummon.getMaxHP() < 0.5)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // 아군의 등급이 모두 하급과 중급인가?
+    public bool AllSummonsLowOrMediumRank(List<Plate> playerPlates)
+    {
+        foreach (Plate plate in playerPlates)
+        {
+            Summon playerSummon = plate.getCurrentSummon();
+            if (playerSummon != null && (playerSummon.getSummonRank() != SummonRank.Low && playerSummon.getSummonRank() != SummonRank.Medium))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // 적의 체력이 하나만 30% 아래인가?
+    public bool isAnyEnemyHealthDown30Percent(List<Plate> enermyPlates)
+    {
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null && enermySummon.getNowHP() / enermySummon.getMaxHP() < 0.3)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // 적의 체력이 70% 이상인가?
+    public bool isAnyEnemyHealthOver70Percent(List<Plate> enermyPlates)
+    {
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null && enermySummon.getNowHP() / enermySummon.getMaxHP() > 0.7)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+
+    // 가장 가까운 적을 공격했을 때 물리칠 수 있는지 확인하는 메소드
+    public bool CanNormalAttackKill(Summon fox, List<Plate> enermyPlates)
+    {
+        int closestIndex = getClosestEnermyIndex(enermyPlates);
+        if (closestIndex != -1)
+        {
+            Summon closestEnermySummon = enermyPlates[closestIndex].getCurrentSummon();
+            if (closestEnermySummon != null && fox.getAttackPower() >= closestEnermySummon.getNowHP())
+            {
+                return true; // 가장 가까운 적을 일반 공격으로 처치할 수 있으면 true 반환
+            }
+        }
+        return false; // 처치할 수 없으면 false 반환
+    }
+
+    public int getClosestEnermyIndex(List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null)
+            {
+                return i; // 가장 가까운(첫 번째로 발견된) 적 소환수의 인덱스 반환
+            }
+        }
+        return -1; // 적 소환수가 없으면 -1 반환
+    }
+}

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/FoxAttackPrediction.cs.meta
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/FoxAttackPrediction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 488ab5df43f41c64cb71e1d2134555ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/RabbitAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/RabbitAttackPrediction.cs
@@ -1,0 +1,129 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RabbitAttackPrediction : MonoBehaviour
+{
+    private PlateController plateController;
+
+    private void Awake()
+    {
+        plateController = GetComponent<PlateController>();
+    }
+
+    // 소환수의 체력 차이가 30% 이상 낮은지 확인하는 메소드
+    // 적 소환수 중 체력 차이가 30% 이상인 경우, 더 낮은 체력을 가진 소환수의 인덱스를 반환하는 메소드
+    public int GetIndexOfLowerHealthIfDifferenceOver30(List<Plate> enermyPlates)
+    {
+        if (enermyPlates.Count < 2) return -1; // 적이 2명 미만이면 비교할 수 없음
+
+        double maxHealthRatio = double.MinValue;
+        double minHealthRatio = double.MaxValue;
+        int indexOfMinHealth = -1;
+
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null)
+            {
+                double healthRatio = enermySummon.getNowHP() / enermySummon.getMaxHP();
+                if (healthRatio < minHealthRatio)
+                {
+                    minHealthRatio = healthRatio;
+                    indexOfMinHealth = i; // 체력이 더 낮은 소환수의 인덱스를 기록
+                }
+                if (healthRatio > maxHealthRatio)
+                {
+                    maxHealthRatio = healthRatio;
+                }
+            }
+        }
+
+        // 체력 차이가 30% 이상인 경우에만 인덱스 반환
+        if ((maxHealthRatio - minHealthRatio) > 0.3f)
+        {
+            return indexOfMinHealth;
+        }
+
+        return -1; // 체력 차이가 30% 이상이 아니면 -1 반환
+    }
+
+
+    // 모든 플레이어 소환수 중 체력이 30% 이하인 소환수 중 가장 낮은 체력을 가진 소환수의 인덱스를 반환하는 메소드
+    public int getIndexOfLowerHealthIfAllDown30(List<Plate> playerPlates)
+    {
+        double minHealthRatio = double.MaxValue;
+        int indexOfMinHealth = -1;
+
+        for (int i = 0; i < playerPlates.Count; i++)
+        {
+            Summon playerSummon = playerPlates[i].getCurrentSummon();
+            if (playerSummon != null)
+            {
+                double healthRatio = playerSummon.getNowHP() / playerSummon.getMaxHP();
+
+                // 모든 소환수가 체력 30% 이하인지 확인
+                if (healthRatio > 0.3f)
+                {
+                    return -1; // 하나라도 체력이 30%를 넘으면 -1 반환
+                }
+
+                // 가장 낮은 체력을 가진 소환수 인덱스를 기록
+                if (healthRatio < minHealthRatio)
+                {
+                    minHealthRatio = healthRatio;
+                    indexOfMinHealth = i;
+                }
+            }
+        }
+
+        return indexOfMinHealth; // 모든 소환수가 30% 이하인 경우 가장 낮은 체력의 인덱스를 반환
+    }
+
+    // 플레이어 소환수의 체력이 모두 70% 이상인지 확인
+    public bool AllPlayerSummonOver70Percent(List<Plate> playerPlates)
+    {
+        foreach (Plate plate in playerPlates)
+        {
+            Summon playerSummon = plate.getCurrentSummon();
+            if (playerSummon != null)
+            {
+                double healthRatio = playerSummon.getNowHP() / playerSummon.getMaxHP();
+                if (healthRatio < 0.7f)
+                {
+                    return false; // 하나라도 70% 이하이면 false 반환
+                }
+            }
+        }
+        return true;
+    }
+
+    // 가장 가까운 적을 공격했을 때 물리칠 수 있는지 확인하는 메소드
+    public bool CanNormalAttackKill(Summon rabbit, List<Plate> enermyPlates)
+    {
+        int closestIndex = getClosestEnermyIndex(enermyPlates);
+        if (closestIndex != -1)
+        {
+            Summon closestEnermySummon = enermyPlates[closestIndex].getCurrentSummon();
+            if (closestEnermySummon != null && rabbit.getAttackPower() >= closestEnermySummon.getNowHP())
+            {
+                return true; // 가장 가까운 적을 일반 공격으로 처치할 수 있으면 true 반환
+            }
+        }
+        return false; // 처치할 수 없으면 false 반환
+    }
+
+
+    public int getClosestEnermyIndex(List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null)
+            {
+                return i; // 가장 가까운(첫 번째로 발견된) 적 소환수의 인덱스 반환
+            }
+        }
+        return -1; // 적 소환수가 없으면 -1 반환
+    }
+}

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/RabbitAttackPrediction.cs.meta
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/RabbitAttackPrediction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6a275dabf9c63b4ead09c092fcf5349
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/SnakeAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/SnakeAttackPrediction.cs
@@ -1,0 +1,135 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SnakeAttackPrediction : MonoBehaviour
+{
+    private PlateController plateController;
+
+    private void Awake()
+    {
+        plateController = GetComponent<PlateController>();
+    }
+
+
+
+
+    // 적이 이미 중독 상태인지 확인하는 메소드
+    public bool IsEnermyAlreadyPoisoned(List<Plate> enermyPlates)
+    {
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null && enermySummon.getAllStatusTypes().Contains(StatusType.Poison))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    // 특수 공격을 사용할 수 있는지 확인하는 메소드
+    public bool canUseSpecialAttack(Summon snake)
+    {
+        var availableSpecialAttacks = snake.getAvailableSpecialAttacks();
+        return availableSpecialAttacks.Length > 0;
+    }
+
+
+
+    // 모든 적의 체력이 50% 이상인지 확인하는 메소드
+    public bool AllEnermyHealthOver50(List<Plate> enermyPlates)
+    {
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null)
+            {
+                double healthRatio = enermySummon.getNowHP() / enermySummon.getMaxHP();
+                if (healthRatio < 0.5)
+                {
+                    return false; // 하나라도 50% 이하이면 false 반환
+                }
+            }
+        }
+        return true;
+    }
+
+
+
+    // 적 중에 공격 개수가 4개 이상인 소환수가 있는지 확인하는 메소드
+    public bool hasMonsterWithMoreThan4Attacks(List<Plate> enermyPlates)
+    {
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null && enermySummon.getSpecialAttackCount() >= 4)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    // 가장 가까운 적을 공격했을 때 물리칠 수 있는지 확인하는 메소드
+    public bool CanNormalAttackKill(Summon snake, List<Plate> enermyPlates)
+    {
+        int closestIndex = getClosestEnermyIndex(enermyPlates);
+        if (closestIndex != -1)
+        {
+            Summon closestEnermySummon = enermyPlates[closestIndex].getCurrentSummon();
+            if (closestEnermySummon != null && snake.getAttackPower() >= closestEnermySummon.getNowHP())
+            {
+                return true; // 가장 가까운 적을 일반 공격으로 처치할 수 있으면 true 반환
+            }
+        }
+        return false; // 처치할 수 없으면 false 반환
+    }
+
+
+    // 적이 2마리 이상 있는지 확인하는 메소드
+    public bool isEnermyCountOverTwo(List<Plate> enermyPlates)
+    {
+        int count = 0;
+        foreach (Plate plate in enermyPlates)
+        {
+            if (plate.getCurrentSummon() != null)
+            {
+                count++;
+                if (count >= 2) return true;
+            }
+        }
+        return false;
+    }
+
+    // 적이 1마리 이상 있는지 확인하는 메소드
+    public bool isEnermyCountOnlyOne(List<Plate> enermyPlates)
+    {
+        foreach (Plate plate in enermyPlates)
+        {
+            if (plate.getCurrentSummon() != null)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+
+
+    public int getClosestEnermyIndex(List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null)
+            {
+                return i; // 가장 가까운(첫 번째로 발견된) 적 소환수의 인덱스 반환
+            }
+        }
+        return -1; // 적 소환수가 없으면 -1 반환
+    }
+}

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/SnakeAttackPrediction.cs.meta
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/SnakeAttackPrediction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7aae015dee961c44d9c756990533d3d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/WolfAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/WolfAttackPrediction.cs
@@ -1,0 +1,225 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class WolfAttackPrediction : MonoBehaviour
+{
+    private PlateController plateController;
+
+    private void Awake()
+    {
+        plateController = GetComponent<PlateController>();
+    }
+
+
+
+    // 적의 체력이 모두 50% 이상인지 확인하는 메소드
+    public bool AllEnermyHealthOver50(List<Plate> enermyPlates)
+    {
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null && enermySummon.getNowHP() / enermySummon.getMaxHP() < 0.5f)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // 적의 체력이 모두 50% 이하인지 확인하는 메소드
+    public bool AllEnermyHealthDown50(List<Plate> enermyPlates)
+    {
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null && enermySummon.getNowHP() / enermySummon.getMaxHP() > 0.5f)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // 적의 체력 차이가 30% 이상인지 확인하는 메소드
+    public bool IsEnermyHealthDifferenceOver30(List<Plate> enermyPlates)
+    {
+        if (enermyPlates.Count < 2) return false;
+
+        double maxHealthRatio = double.MinValue;
+        double minHealthRatio = double.MaxValue;
+
+        foreach (Plate plate in enermyPlates)
+        {
+            Summon enermySummon = plate.getCurrentSummon();
+            if (enermySummon != null)
+            {
+                double healthRatio = enermySummon.getNowHP() / enermySummon.getMaxHP();
+                if (healthRatio > maxHealthRatio) maxHealthRatio = healthRatio;
+                if (healthRatio < minHealthRatio) minHealthRatio = healthRatio;
+            }
+        }
+
+        return (maxHealthRatio - minHealthRatio) > 0.3f;
+    }
+
+    // 적의 체력 차이가 30% 이상인지 확인하고, 체력이 가장 낮은 몬스터의 인덱스를 가져와 근접한 인덱스와 비교하는 메소드
+    public bool IsLowestHealthEnermyClosest(Summon attackingSummon, List<Plate> enermyPlates)
+    {
+        // 적 소환수가 2개 미만인 경우 비교할 수 없으므로 false 반환
+        if (enermyPlates.Count < 2) return false;
+
+        double maxHealthRatio = double.MinValue;
+        double minHealthRatio = double.MaxValue;
+        int lowestHealthIndex = -1;
+
+        // 적 몬스터의 최대 체력 비율과 최소 체력 비율을 계산하고, 최소 체력을 가진 인덱스 저장
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null)
+            {
+                double healthRatio = enermySummon.getNowHP() / enermySummon.getMaxHP();
+                if (healthRatio > maxHealthRatio) maxHealthRatio = healthRatio;
+                if (healthRatio < minHealthRatio)
+                {
+                    minHealthRatio = healthRatio;
+                    lowestHealthIndex = i;
+                }
+            }
+        }
+
+        // 체력 비율의 차이가 30% 이상인지 확인
+        if ((maxHealthRatio - minHealthRatio) > 0.3f)
+        {
+            // 체력이 가장 낮은 적 소환수의 인덱스와 가장 가까운 적 소환수의 인덱스를 비교
+            int closestIndex = getClosestEnermyIndex(attackingSummon , enermyPlates);
+            return (lowestHealthIndex == closestIndex);
+        }
+
+        return false; // 체력 차이가 30% 이상이 아니거나 조건을 만족하지 않으면 false 반환
+    }
+
+    // 가장 가까운 적 소환수의 인덱스를 반환하는 메소드
+    public int getClosestEnermyIndex(Summon attackingSummon, List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null && enermySummon != attackingSummon)
+            {
+                return i; // 첫 번째로 만나는 유효한 적 소환수의 인덱스를 반환
+            }
+        }
+
+        return -1; // 적 소환수가 없는 경우 -1 반환
+    }
+
+
+    public int getClosestEnermyIndex(List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null)
+            {
+                return i; // 가장 가까운(첫 번째로 발견된) 적 소환수의 인덱스 반환
+            }
+        }
+        return -1; // 적 소환수가 없으면 -1 반환
+    }
+
+
+    // 적이 2마리 이상인지 확인하는 메소드
+    public bool IsEnermyCountTwoOrMore(List<Plate> enermyPlates)
+    {
+        return enermyPlates.Count >= 2;
+    }
+
+    // 적이 1마리인지 확인하는 메소드
+    public bool IsEnermyCountOne(List<Plate> enermyPlates)
+    {
+        return enermyPlates.Count == 1;
+    }
+
+
+    // 자기 자신을 제외하고 플레이어의 소환수에 특정 특수 공격 상태가 있는지 확인하는 메소드
+    public bool HasSpecificAvailableSpecialAttack(Summon self, List<Plate> playerPlates)
+    {
+        // 검사할 특수 공격 상태 타입들 (None, Burn, Poison, LifeDrain)
+        StatusType[] specificStatuses = new StatusType[] { StatusType.None, StatusType.Burn, StatusType.Poison, StatusType.LifeDrain };
+
+        foreach (Plate plate in playerPlates)
+        {
+            Summon playerSummon = plate.getCurrentSummon();
+            // 자기 자신을 제외하고 검사
+            if (playerSummon != null && playerSummon != self)
+            {
+                // 소환수의 사용 가능한 특수 공격들을 가져옴
+                IAttackStrategy[] availableSpecialAttacks = playerSummon.getAvailableSpecialAttacks();
+
+                // 사용 가능한 특수 공격 중 특정 상태가 있는지 확인
+                foreach (IAttackStrategy specialAttack in availableSpecialAttacks)
+                {
+                    if (specialAttack != null && specificStatuses.Contains(specialAttack.getStatusType()))
+                    {
+                        // 특정 상태가 있는 특수 공격이 있다면 true 반환
+                        return true;
+                    }
+                }
+            }
+        }
+        return false; // 특정 상태가 없으면 false 반환
+    }
+
+
+    // 일반 공격으로 적을 물리칠 수 있는 가장 가까운 인덱스를 반환하는 메소드
+    public int getIndexofNormalAttackCanKill(Summon attackingSummon, List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null && attackingSummon.getAttackPower() >= enermySummon.getNowHP())
+            {
+                // 일반 공격으로 적의 체력을 0 이하로 만들 수 있으면 해당 인덱스 반환
+                return i;
+            }
+        }
+        return -1; // 공격 가능한 적이 없으면 -1 반환
+    }
+
+    public AttackType getMostDamageAttack(Summon attackingSummon, List<Plate> enermyPlates)
+    {
+        double maxDamage = attackingSummon.getAttackPower(); // 기본값: 일반 공격의 데미지
+
+
+        // 사용 가능한 특수 공격 목록 가져오기
+        IAttackStrategy[] availableSpecialAttacks = attackingSummon.getAvailableSpecialAttacks();
+
+        // 각 특수 공격 확인
+        foreach (IAttackStrategy specialAttack in availableSpecialAttacks)
+        {
+            double totalSpecialAttackDamage = 0;
+
+            // 적 플레이트에 있는 모든 소환수에게 특수 공격 시 예상 피해 축적
+            foreach (Plate plate in enermyPlates)
+            {
+                Summon enermySummon = plate.getCurrentSummon();
+                if (enermySummon != null)
+                {
+                    totalSpecialAttackDamage += specialAttack.getSpecialDamage();
+                }
+            }
+
+            // 특수 공격으로 총 피해가 일반 공격보다 크다면 업데이트
+            if (totalSpecialAttackDamage > maxDamage)
+            {
+                maxDamage = totalSpecialAttackDamage;
+                return AttackType.SpecialAttack;
+            }
+        }
+
+        return AttackType.NormalAttack;
+    }
+}

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/WolfAttackPrediction.cs.meta
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/WolfAttackPrediction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dee950ed2629dc8498d71778e1d94f71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
@@ -16,6 +16,7 @@ public class Cat : Summon
         nowHP = maxHP;
         attackPower = 15; //일반공격
         summonRank = SummonRank.Low; // 하급 소환수
+        summonType = SummonType.Cat;
         heavyAttakPower = 20;
         // 일반 공격: 가장 가까운 적 공격
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower ,1);

--- a/Workpiece/Summoner/Assets/Script/Summons/Eagle.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Eagle.cs
@@ -16,6 +16,7 @@ public class Eagle : Summon
         nowHP = maxHP;
         attackPower = 45; //일반공격
         summonRank = SummonRank.High; // 상급 소환수
+        summonType = SummonType.Eagle;
         heavyAttakPower = 30;
         // 일반 공격: 가장 가까운 적 공격
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 1);

--- a/Workpiece/Summoner/Assets/Script/Summons/Fox.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Fox.cs
@@ -19,7 +19,7 @@ public class Fox : Summon
         nowHP = maxHP; //현재체력 // 깨어날땐 최대체력으로 설정
         attackPower = 15; //일반공격
         summonRank = SummonRank.Low; // 하급 소환수
-
+        summonType = SummonType.Fox;
         // 일반 공격: 가장 가까운 적 공격
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 0);
         specialAttackStrategies = new IAttackStrategy[] { new TargetedAttackStrategy(StatusType.Upgrade, 0.2, 3, 1) };//공격력 강화, 20% 상승, 쿨타임 2턴

--- a/Workpiece/Summoner/Assets/Script/Summons/Rabbit.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Rabbit.cs
@@ -17,7 +17,7 @@ public class Rabbit : Summon
         nowHP = maxHP;
         attackPower = 20; //일반공격
         summonRank = SummonRank.Medium; // 중급 소환수
-
+        summonType = SummonType.Rabbit;
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower,1); //근접공격
         specialAttackStrategies = new IAttackStrategy[] { new TargetedAttackStrategy(StatusType.Heal, 0.3, 3) };
     }

--- a/Workpiece/Summoner/Assets/Script/Summons/Snake.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Snake.cs
@@ -16,7 +16,7 @@ public class Snake : Summon
         nowHP = maxHP;
         attackPower = 30; //일반공격
         summonRank = SummonRank.Medium; // 중급 소환수
-
+        summonType = SummonType.Snake;
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 1); //근접 공격
         specialAttackStrategies = new IAttackStrategy[] { new AttackAllEnemiesStrategy(StatusType.Poison, 0.1, 3, 3) };//중독, 체력에10% 쿨타임3턴 지속시간3턴
     }

--- a/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
@@ -10,6 +10,11 @@ public enum SummonRank
     Normal, Special, Boss //적 소환수
 }
 
+public enum SummonType
+{
+    Cat, Rabbit, Wolf, Eagle, Snake, Fox
+}
+
 public class Summon : MonoBehaviour
 {
     [SerializeField] private Image image; //이미지
@@ -19,6 +24,7 @@ public class Summon : MonoBehaviour
     protected double attackPower; //일반공격
     protected double heavyAttakPower; //강 공격력
     protected SummonRank summonRank; //등급
+    protected SummonType summonType;
     protected double maxHP; //최대체력
     public double nowHP; //현재 체력
     protected double shield = 0; //쉴드량
@@ -260,6 +266,12 @@ public class Summon : MonoBehaviour
     {
         this.isAttack = isAttack;
     }
+
+    public SummonType getSummonType()
+    {
+        return summonType;
+    }
+    
 
     public void UpgradeAttackPower(double multiplier)
     {
@@ -530,4 +542,11 @@ public class Summon : MonoBehaviour
 
         return availableSpecialAttacks.ToArray();
     }
+
+
+    public int getSpecialAttackCount()
+    {
+        return specialAttackStrategies.Length;
+    }
+
 }

--- a/Workpiece/Summoner/Assets/Script/Summons/Wolf.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Wolf.cs
@@ -16,7 +16,7 @@ public class Wolf : Summon
         nowHP = maxHP;
         attackPower = 50; //일반공격
         summonRank = SummonRank.High; // 중급 소환수
-
+        summonType = SummonType.Wolf;
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 1); //근접공격
         specialAttackStrategies = new IAttackStrategy[] { new AttackAllEnemiesStrategy(StatusType.None, 25, 2) };//전체공격, 25데미지, 쿨타임2턴
     }


### PR DESCRIPTION
독수리에 특수공격으로 죽일 수 있을경우 일반공격의 확률을 10% 올린다 써있는데 특수공격이 상승하도록 했습니다.

타겟공격의 경우 플레이트를 랜덤으로 하고있는데 그렇게 되면
토끼의 힐과 독수리의 타겟공격이 서로 상반되있어서 힐을 주지만 적 플레이트를 힐 해버릴 수 있기때문에 이 부분은 로직으로 구현이 매우 까다롭습니다.