### PR TITLE
StatePanel 버그 수정 + 알고리즘 수정

### DIFF
--- a/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_1Stage.unity
+++ b/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_1Stage.unity
@@ -995,44 +995,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &173288603
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 173288604}
-  m_Layer: 5
-  m_Name: EmenyImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &173288604
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 173288603}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 449632637}
-  - {fileID: 1101961206}
-  - {fileID: 1961257247}
-  m_Father: {fileID: 313031150}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &179737535 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7001086004006574865, guid: 425618ad78d48fc47930e89c04062585, type: 3}
@@ -1798,7 +1760,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1545898996}
-  - {fileID: 173288604}
   m_Father: {fileID: 893681167}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2491,97 +2452,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_EffectDistance: {x: 5, y: -5}
-  m_UseGraphicAlpha: 1
---- !u!1 &449632636
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 449632637}
-  - component: {fileID: 449632639}
-  - component: {fileID: 449632638}
-  - component: {fileID: 449632640}
-  m_Layer: 5
-  m_Name: FirstImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &449632637
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 449632636}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 173288604}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 240, y: 50}
-  m_SizeDelta: {x: 400, y: 400}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &449632638
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 449632636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -1339472230, guid: 5d38447b6e33bef439ff62b12b1b5bef, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &449632639
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 449632636}
-  m_CullTransparentMesh: 1
---- !u!114 &449632640
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 449632636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
-  m_EffectDistance: {x: 10, y: -10}
   m_UseGraphicAlpha: 1
 --- !u!1 &521371645
 GameObject:
@@ -4511,12 +4381,12 @@ GameObject:
   - component: {fileID: 893681171}
   - component: {fileID: 893681170}
   - component: {fileID: 893681179}
-  - component: {fileID: 893681178}
-  - component: {fileID: 893681177}
-  - component: {fileID: 893681176}
-  - component: {fileID: 893681175}
-  - component: {fileID: 893681174}
-  - component: {fileID: 893681173}
+  - component: {fileID: 893681185}
+  - component: {fileID: 893681184}
+  - component: {fileID: 893681183}
+  - component: {fileID: 893681182}
+  - component: {fileID: 893681181}
+  - component: {fileID: 893681180}
   m_Layer: 5
   m_Name: Player_Enermy
   m_TagString: Untagged
@@ -4631,7 +4501,19 @@ MonoBehaviour:
   - {fileID: 9184813848463463012}
   - {fileID: 1856290379}
   - {fileID: 792077600}
---- !u!114 &893681173
+--- !u!114 &893681179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f4208a767cafbe48a458450dba43d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681180
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4643,7 +4525,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dee950ed2629dc8498d71778e1d94f71, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &893681174
+--- !u!114 &893681181
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4655,7 +4537,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7aae015dee961c44d9c756990533d3d1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &893681175
+--- !u!114 &893681182
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4667,31 +4549,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6a275dabf9c63b4ead09c092fcf5349, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &893681176
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893681166}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f43ba149b0784942a9fa334d497d6fd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &893681177
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893681166}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0fcb56653b5fa2e4f8efb66dfd65b205, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &893681178
+--- !u!114 &893681183
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4703,7 +4561,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 488ab5df43f41c64cb71e1d2134555ef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &893681179
+--- !u!114 &893681184
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4712,7 +4570,19 @@ MonoBehaviour:
   m_GameObject: {fileID: 893681166}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f4208a767cafbe48a458450dba43d0a, type: 3}
+  m_Script: {fileID: 11500000, guid: 0fcb56653b5fa2e4f8efb66dfd65b205, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681185
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f43ba149b0784942a9fa334d497d6fd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &959924360
@@ -5350,97 +5220,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1090429553}
   m_CullTransparentMesh: 1
---- !u!1 &1101961205
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1101961206}
-  - component: {fileID: 1101961208}
-  - component: {fileID: 1101961207}
-  - component: {fileID: 1101961209}
-  m_Layer: 5
-  m_Name: SecondImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1101961206
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1101961205}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 173288604}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 470, y: 50}
-  m_SizeDelta: {x: 400, y: 400}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1101961207
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1101961205}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -364337671, guid: 38c529a945d367a4db8b08f028dde9c9, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1101961208
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1101961205}
-  m_CullTransparentMesh: 1
---- !u!114 &1101961209
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1101961205}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
-  m_EffectDistance: {x: 10, y: -10}
-  m_UseGraphicAlpha: 1
 --- !u!1 &1152497996
 GameObject:
   m_ObjectHideFlags: 0
@@ -9231,97 +9010,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   summon: {fileID: 0}
---- !u!1 &1961257246
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1961257247}
-  - component: {fileID: 1961257249}
-  - component: {fileID: 1961257248}
-  - component: {fileID: 1961257250}
-  m_Layer: 5
-  m_Name: ThirdImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1961257247
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1961257246}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 173288604}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 700, y: 70}
-  m_SizeDelta: {x: 500, y: 500}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1961257248
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1961257246}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -268698255, guid: 11098ad80c0747d4496915a99d246248, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1961257249
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1961257246}
-  m_CullTransparentMesh: 1
---- !u!114 &1961257250
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1961257246}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
-  m_EffectDistance: {x: 10, y: -10}
-  m_UseGraphicAlpha: 1
 --- !u!1 &2056378203
 GameObject:
   m_ObjectHideFlags: 0

--- a/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_2Stage.unity
+++ b/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_2Stage.unity
@@ -1369,7 +1369,7 @@ MonoBehaviour:
   - {fileID: 1198668647}
   - {fileID: 2108069854}
   - {fileID: 965398383}
-  - {fileID: 0}
+  - {fileID: 653879316}
   takeSummonPanel: {fileID: 1196271517}
   selectSummonPanels:
   - {fileID: 1178627254}
@@ -1518,6 +1518,8 @@ GameObject:
   m_Component:
   - component: {fileID: 313031150}
   - component: {fileID: 313031151}
+  - component: {fileID: 313031153}
+  - component: {fileID: 313031152}
   m_Layer: 5
   m_Name: Enermy
   m_TagString: Untagged
@@ -1559,6 +1561,34 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   turnController: {fileID: 893681170}
+--- !u!114 &313031152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd2e37e0a8a3a604a802e36f2693bc28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
+  playerAttackPrediction: {fileID: 893681173}
+  battleController: {fileID: 893681171}
+--- !u!114 &313031153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
 --- !u!1 &320502377
 GameObject:
   m_ObjectHideFlags: 0
@@ -3434,6 +3464,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4558713133135357039, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
   m_PrefabInstance: {fileID: 653879313}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &653879316 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1190882339284521166, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
+  m_PrefabInstance: {fileID: 653879313}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1efcb282fa10014fa4ca2d91f0801f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &658067649
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4542,6 +4583,12 @@ GameObject:
   - component: {fileID: 893681171}
   - component: {fileID: 893681170}
   - component: {fileID: 893681173}
+  - component: {fileID: 893681179}
+  - component: {fileID: 893681178}
+  - component: {fileID: 893681177}
+  - component: {fileID: 893681176}
+  - component: {fileID: 893681175}
+  - component: {fileID: 893681174}
   m_Layer: 5
   m_Name: Player_Enermy
   m_TagString: Untagged
@@ -4665,10 +4712,81 @@ MonoBehaviour:
   m_GameObject: {fileID: 893681166}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Script: {fileID: 11500000, guid: 3f4208a767cafbe48a458450dba43d0a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  plateController: {fileID: 893681172}
+--- !u!114 &893681174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dee950ed2629dc8498d71778e1d94f71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7aae015dee961c44d9c756990533d3d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6a275dabf9c63b4ead09c092fcf5349, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 488ab5df43f41c64cb71e1d2134555ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fcb56653b5fa2e4f8efb66dfd65b205, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f43ba149b0784942a9fa334d497d6fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &902334995 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6357672399787545836, guid: 3c7c2537101f88c49ad31ede087e9727, type: 3}

--- a/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_3Stage.unity
+++ b/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_3Stage.unity
@@ -1149,6 +1149,7 @@ MonoBehaviour:
   - {fileID: 1678701020}
   - {fileID: 2061794237}
   - {fileID: 1872720142}
+  - {fileID: 1713057989}
   takeSummonPanel: {fileID: 1196271517}
   selectSummonPanels:
   - {fileID: 1178627254}
@@ -1297,6 +1298,8 @@ GameObject:
   m_Component:
   - component: {fileID: 313031150}
   - component: {fileID: 313031151}
+  - component: {fileID: 313031153}
+  - component: {fileID: 313031152}
   m_Layer: 5
   m_Name: Enermy
   m_TagString: Untagged
@@ -1337,6 +1340,34 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   turnController: {fileID: 893681170}
+--- !u!114 &313031152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
+--- !u!114 &313031153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd2e37e0a8a3a604a802e36f2693bc28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
+  playerAttackPrediction: {fileID: 893681173}
+  battleController: {fileID: 893681171}
 --- !u!1 &323705123
 GameObject:
   m_ObjectHideFlags: 0
@@ -4223,6 +4254,12 @@ GameObject:
   - component: {fileID: 893681171}
   - component: {fileID: 893681170}
   - component: {fileID: 893681173}
+  - component: {fileID: 893681179}
+  - component: {fileID: 893681178}
+  - component: {fileID: 893681177}
+  - component: {fileID: 893681176}
+  - component: {fileID: 893681175}
+  - component: {fileID: 893681174}
   m_Layer: 5
   m_Name: Player_Enermy
   m_TagString: Untagged
@@ -4346,10 +4383,81 @@ MonoBehaviour:
   m_GameObject: {fileID: 893681166}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Script: {fileID: 11500000, guid: 3f4208a767cafbe48a458450dba43d0a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  plateController: {fileID: 893681172}
+--- !u!114 &893681174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dee950ed2629dc8498d71778e1d94f71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7aae015dee961c44d9c756990533d3d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6a275dabf9c63b4ead09c092fcf5349, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 488ab5df43f41c64cb71e1d2134555ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fcb56653b5fa2e4f8efb66dfd65b205, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f43ba149b0784942a9fa334d497d6fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &959924360
 GameObject:
   m_ObjectHideFlags: 0
@@ -7682,6 +7790,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4558713133135357039, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
   m_PrefabInstance: {fileID: 1713057987}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1713057989 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1190882339284521166, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
+  m_PrefabInstance: {fileID: 1713057987}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1efcb282fa10014fa4ca2d91f0801f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1719423185
 GameObject:
   m_ObjectHideFlags: 0

--- a/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_4Stage.unity
+++ b/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_4Stage.unity
@@ -1490,7 +1490,7 @@ MonoBehaviour:
   - {fileID: 107530138}
   - {fileID: 1865683338}
   - {fileID: 354856082}
-  - {fileID: 0}
+  - {fileID: 968137026}
   takeSummonPanel: {fileID: 1196271517}
   selectSummonPanels:
   - {fileID: 1178627254}
@@ -1639,6 +1639,8 @@ GameObject:
   m_Component:
   - component: {fileID: 313031150}
   - component: {fileID: 313031151}
+  - component: {fileID: 313031153}
+  - component: {fileID: 313031152}
   m_Layer: 5
   m_Name: Enermy
   m_TagString: Untagged
@@ -1680,6 +1682,34 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   turnController: {fileID: 893681170}
+--- !u!114 &313031152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
+--- !u!114 &313031153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd2e37e0a8a3a604a802e36f2693bc28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
+  playerAttackPrediction: {fileID: 893681173}
+  battleController: {fileID: 893681171}
 --- !u!1 &323705123
 GameObject:
   m_ObjectHideFlags: 0
@@ -4437,6 +4467,12 @@ GameObject:
   - component: {fileID: 893681171}
   - component: {fileID: 893681170}
   - component: {fileID: 893681173}
+  - component: {fileID: 893681179}
+  - component: {fileID: 893681178}
+  - component: {fileID: 893681177}
+  - component: {fileID: 893681176}
+  - component: {fileID: 893681175}
+  - component: {fileID: 893681174}
   m_Layer: 5
   m_Name: Player_Enermy
   m_TagString: Untagged
@@ -4560,10 +4596,81 @@ MonoBehaviour:
   m_GameObject: {fileID: 893681166}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Script: {fileID: 11500000, guid: 3f4208a767cafbe48a458450dba43d0a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  plateController: {fileID: 893681172}
+--- !u!114 &893681174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dee950ed2629dc8498d71778e1d94f71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7aae015dee961c44d9c756990533d3d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6a275dabf9c63b4ead09c092fcf5349, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 488ab5df43f41c64cb71e1d2134555ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fcb56653b5fa2e4f8efb66dfd65b205, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f43ba149b0784942a9fa334d497d6fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &959924360
 GameObject:
   m_ObjectHideFlags: 0
@@ -4888,6 +4995,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4558713133135357039, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
   m_PrefabInstance: {fileID: 968137024}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &968137026 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1190882339284521166, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
+  m_PrefabInstance: {fileID: 968137024}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1efcb282fa10014fa4ca2d91f0801f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &975623082
 GameObject:
   m_ObjectHideFlags: 0

--- a/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_5Stage.unity
+++ b/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_5Stage.unity
@@ -1369,7 +1369,7 @@ MonoBehaviour:
   - {fileID: 1738089334}
   - {fileID: 1427656904}
   - {fileID: 1669204719}
-  - {fileID: 0}
+  - {fileID: 972424002}
   takeSummonPanel: {fileID: 1196271517}
   selectSummonPanels:
   - {fileID: 1178627254}
@@ -1518,6 +1518,8 @@ GameObject:
   m_Component:
   - component: {fileID: 313031150}
   - component: {fileID: 313031151}
+  - component: {fileID: 313031153}
+  - component: {fileID: 313031152}
   m_Layer: 5
   m_Name: Enermy
   m_TagString: Untagged
@@ -1559,6 +1561,34 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   turnController: {fileID: 893681170}
+--- !u!114 &313031152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd2e37e0a8a3a604a802e36f2693bc28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
+  playerAttackPrediction: {fileID: 893681173}
+  battleController: {fileID: 893681171}
+--- !u!114 &313031153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
 --- !u!1 &323705123
 GameObject:
   m_ObjectHideFlags: 0
@@ -4074,6 +4104,12 @@ GameObject:
   - component: {fileID: 893681171}
   - component: {fileID: 893681170}
   - component: {fileID: 893681173}
+  - component: {fileID: 893681179}
+  - component: {fileID: 893681178}
+  - component: {fileID: 893681177}
+  - component: {fileID: 893681176}
+  - component: {fileID: 893681175}
+  - component: {fileID: 893681174}
   m_Layer: 5
   m_Name: Player_Enermy
   m_TagString: Untagged
@@ -4197,10 +4233,81 @@ MonoBehaviour:
   m_GameObject: {fileID: 893681166}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Script: {fileID: 11500000, guid: 3f4208a767cafbe48a458450dba43d0a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  plateController: {fileID: 893681172}
+--- !u!114 &893681174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dee950ed2629dc8498d71778e1d94f71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7aae015dee961c44d9c756990533d3d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6a275dabf9c63b4ead09c092fcf5349, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 488ab5df43f41c64cb71e1d2134555ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fcb56653b5fa2e4f8efb66dfd65b205, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f43ba149b0784942a9fa334d497d6fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &958636150
 GameObject:
   m_ObjectHideFlags: 0
@@ -4525,6 +4632,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4558713133135357039, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
   m_PrefabInstance: {fileID: 972424000}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &972424002 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1190882339284521166, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
+  m_PrefabInstance: {fileID: 972424000}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1efcb282fa10014fa4ca2d91f0801f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &975623082
 GameObject:
   m_ObjectHideFlags: 0

--- a/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_6Stage.unity
+++ b/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_6Stage.unity
@@ -1503,7 +1503,7 @@ MonoBehaviour:
   - {fileID: 447504763}
   - {fileID: 2147059044}
   - {fileID: 2124055269}
-  - {fileID: 0}
+  - {fileID: 959923866}
   takeSummonPanel: {fileID: 1196271517}
   selectSummonPanels:
   - {fileID: 1178627254}
@@ -1652,6 +1652,8 @@ GameObject:
   m_Component:
   - component: {fileID: 313031150}
   - component: {fileID: 313031151}
+  - component: {fileID: 313031153}
+  - component: {fileID: 313031152}
   m_Layer: 5
   m_Name: Enermy
   m_TagString: Untagged
@@ -1693,6 +1695,34 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   turnController: {fileID: 893681170}
+--- !u!114 &313031152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd2e37e0a8a3a604a802e36f2693bc28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
+  playerAttackPrediction: {fileID: 893681173}
+  battleController: {fileID: 893681171}
+--- !u!114 &313031153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
 --- !u!1 &323705123
 GameObject:
   m_ObjectHideFlags: 0
@@ -4329,6 +4359,12 @@ GameObject:
   - component: {fileID: 893681171}
   - component: {fileID: 893681170}
   - component: {fileID: 893681173}
+  - component: {fileID: 893681179}
+  - component: {fileID: 893681178}
+  - component: {fileID: 893681177}
+  - component: {fileID: 893681176}
+  - component: {fileID: 893681175}
+  - component: {fileID: 893681174}
   m_Layer: 5
   m_Name: Player_Enermy
   m_TagString: Untagged
@@ -4452,10 +4488,81 @@ MonoBehaviour:
   m_GameObject: {fileID: 893681166}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Script: {fileID: 11500000, guid: 3f4208a767cafbe48a458450dba43d0a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  plateController: {fileID: 893681172}
+--- !u!114 &893681174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dee950ed2629dc8498d71778e1d94f71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7aae015dee961c44d9c756990533d3d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6a275dabf9c63b4ead09c092fcf5349, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 488ab5df43f41c64cb71e1d2134555ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fcb56653b5fa2e4f8efb66dfd65b205, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f43ba149b0784942a9fa334d497d6fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &959923864
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4570,6 +4677,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4558713133135357039, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
   m_PrefabInstance: {fileID: 959923864}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &959923866 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1190882339284521166, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
+  m_PrefabInstance: {fileID: 959923864}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1efcb282fa10014fa4ca2d91f0801f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &959924360
 GameObject:
   m_ObjectHideFlags: 0

--- a/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_7Stage.unity
+++ b/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_7Stage.unity
@@ -1358,7 +1358,7 @@ MonoBehaviour:
   - {fileID: 463877842}
   - {fileID: 1543422439}
   - {fileID: 1007355987}
-  - {fileID: 0}
+  - {fileID: 940324145}
   takeSummonPanel: {fileID: 1196271517}
   selectSummonPanels:
   - {fileID: 1178627254}
@@ -1507,6 +1507,8 @@ GameObject:
   m_Component:
   - component: {fileID: 313031150}
   - component: {fileID: 313031151}
+  - component: {fileID: 313031153}
+  - component: {fileID: 313031152}
   m_Layer: 5
   m_Name: Enermy
   m_TagString: Untagged
@@ -1548,6 +1550,34 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   turnController: {fileID: 893681170}
+--- !u!114 &313031152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd2e37e0a8a3a604a802e36f2693bc28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
+  playerAttackPrediction: {fileID: 893681173}
+  battleController: {fileID: 893681171}
+--- !u!114 &313031153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313031149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plateController: {fileID: 893681172}
 --- !u!1 &323705123
 GameObject:
   m_ObjectHideFlags: 0
@@ -4013,6 +4043,12 @@ GameObject:
   - component: {fileID: 893681171}
   - component: {fileID: 893681170}
   - component: {fileID: 893681173}
+  - component: {fileID: 893681179}
+  - component: {fileID: 893681178}
+  - component: {fileID: 893681177}
+  - component: {fileID: 893681176}
+  - component: {fileID: 893681175}
+  - component: {fileID: 893681174}
   m_Layer: 5
   m_Name: Player_Enermy
   m_TagString: Untagged
@@ -4134,10 +4170,81 @@ MonoBehaviour:
   m_GameObject: {fileID: 893681166}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bf862d93ab88f8f4cb20c74da9f460f2, type: 3}
+  m_Script: {fileID: 11500000, guid: 3f4208a767cafbe48a458450dba43d0a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  plateController: {fileID: 893681172}
+--- !u!114 &893681174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dee950ed2629dc8498d71778e1d94f71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7aae015dee961c44d9c756990533d3d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6a275dabf9c63b4ead09c092fcf5349, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 488ab5df43f41c64cb71e1d2134555ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fcb56653b5fa2e4f8efb66dfd65b205, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &893681179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893681166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f43ba149b0784942a9fa334d497d6fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &940324143
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4252,6 +4359,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4558713133135357039, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
   m_PrefabInstance: {fileID: 940324143}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &940324145 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1190882339284521166, guid: dff2b5038caad10488ae21b2d2ed5eb7, type: 3}
+  m_PrefabInstance: {fileID: 940324143}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1efcb282fa10014fa4ca2d91f0801f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &959924360
 GameObject:
   m_ObjectHideFlags: 0

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleController.cs
@@ -51,7 +51,7 @@ public class BattleController : MonoBehaviour
         }
 
         // 사용 가능한 특수 공격을 배열 인덱스로 가져옴
-        IAttackStrategy attackStrategy = attackSummon.getAvailableSpecialAttacks()[selectSpecialAttackIndex];
+        IAttackStrategy attackStrategy = attackSummon.getSpecialAttackStrategy()[selectSpecialAttackIndex];
 
         // 공격 타입별로 로직 수행
         if (attackStrategy is TargetedAttackStrategy targetedAttack)

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/AttackAllEnemiesStrategy.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/AttackAllEnemiesStrategy.cs
@@ -46,7 +46,7 @@ public class AttackAllEnemiesStrategy : IAttackStrategy
                         Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}에게 화상을 입혀 매 턴 {burnDamage} 데미지를 입힙니다.");
                         break;
                     case StatusType.Upgrade:
-                        double upgradeAttackPower = target.getAttackPower() * attacker.getSpecialAttackStrategy()[SpecialAttackArrayIndex].getSpecialDamage();
+                        double upgradeAttackPower = attacker.getSpecialAttackStrategy()[SpecialAttackArrayIndex].getSpecialDamage();
                         StatusEffect upgradeEffect = new StatusEffect(StatusType.Upgrade, statusTime, upgradeAttackPower);
                         target.ApplyStatusEffect(upgradeEffect);
                         Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}에게 공격력 {upgradeAttackPower} 만큼 상승 시켰습니다.");

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/StatusEffect.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/StatusEffect.cs
@@ -25,12 +25,15 @@ public class StatusEffect
 
     private Summon attacker; // 공격자
 
+    private bool applyOnce = false;
+
     public StatusEffect(StatusType type, int eTime, double damage=0, Summon attacker = null)
     {
         statusType = type;
         effectTime = eTime;
         damagePerTurn = damage;
         this.attacker = attacker;
+        applyOnce = false;
     }
 
 
@@ -73,10 +76,23 @@ public class StatusEffect
             case StatusType.Upgrade: //강화
                 target.UpgradeAttackPower(damagePerTurn);
                 break;
+            case StatusType.Curse: //저주
+                target.Cursed(damagePerTurn);
+                break;
 
             default:
                 Debug.Log("정의되지 않은 상태이상입니다.");
                 break;
         }
+    }
+
+    public bool shouldApplyOnce()
+    {
+        return damagePerTurn > 0 && !applyOnce;
+    }
+
+    public void setApplyOnce()
+    {
+        applyOnce = true; // 한 번만 적용되도록 표시
     }
 }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/TargetedAttackStrategy.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/TargetedAttackStrategy.cs
@@ -48,19 +48,19 @@ public class TargetedAttackStrategy : IAttackStrategy
                     Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}에게 {damage} 만큼 보호막을 부여합니다.");
                     break;
                 case StatusType.Upgrade: //강화
-                    double upgradeAttackPower = target.getAttackPower() * attacker.getSpecialAttackStrategy()[Arrayindex].getSpecialDamage();
+                    double upgradeAttackPower = attacker.getSpecialAttackStrategy()[Arrayindex].getSpecialDamage();
                     StatusEffect upgradeEffect = new StatusEffect(StatusType.Upgrade, statusTime, upgradeAttackPower);
                     target.ApplyStatusEffect(upgradeEffect);
-                    Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}에게 공격력 {upgradeAttackPower} 만큼 상승 시켰습니다.");
+                    Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}에게 공격력 {upgradeAttackPower*100} 만큼 상승 시켰습니다.");
                     break;
                 case StatusType.OnceInvincibility: //무적
                     target = attacker; //자기자신이 대상
                     target.setOnceInvincibility(true); //1번 무적 활성화
                     break;
                 case StatusType.Curse: //저주
-                    double curseAttackPower = target.getAttackPower() - (target.getAttackPower() * 0.2); //대상 공격력 20% 감소
-                    Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}을(를) 강력하게 공격합니다.");
-                    StatusEffect curseEffect = new StatusEffect(StatusType.Upgrade, statusTime, curseAttackPower);
+                    double curseAttackPower =  attacker.getSpecialAttackStrategy()[Arrayindex].getSpecialDamage(); //대상 공격력 20% 감소
+                    Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}에게  공격력 {curseAttackPower * 100} 만큼 저주를 걸었습니다.");
+                    StatusEffect curseEffect = new StatusEffect(StatusType.Curse, statusTime, curseAttackPower);
                     target.ApplyStatusEffect(curseEffect);
                     target.takeDamage(attacker.getSpecialAttackStrategy()[Arrayindex].getSpecialDamage()); // 강력한 공격
                     break;

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Character.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Character.cs
@@ -7,20 +7,6 @@ using UnityEngine;
 public class Character : MonoBehaviour
 {
    
-    public virtual void startTurn()
-    {
-        Debug.Log($"{gameObject.name}의 턴 시작");
-        //턴 시작시 할 행동 추가 가능
-    }
 
-    public virtual void takeAction()
-    {
-        //해당 플레이어가 취할 액션 시작
-    }
-
-    public virtual void EndTurn()
-    {
-        Debug.Log($"{gameObject.name}의 턴 종료");
-    }
 
 }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/TurnController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/TurnController.cs
@@ -27,25 +27,36 @@ public class TurnController : MonoBehaviour
     {
         if (currentTurn == Turn.PlayerTurn)  // 플레이어 턴일 경우
         {
-            player.startTurn();
-
             //플레이어 턴 시작시 적 플레이트의 상태이상 데미지 적용
             foreach (var summon in enermy.getEnermyAttackController().getPlateController().getEnermySummons())
             {
-                summon.UpdateStatusEffectsAndCooldowns(); // 상태이상 업데이트
+                summon.UpdateDamageStatusEffects(); // 데미지를 주는 상태이상 업데이트
+                summon.UpdateStunAndCurseStatus(); // 스턴 및 저주 상태 업데이트
                 summon.getAttackStrategy().ReduceCooldown(); // 일반 공격 쿨타임 감소
             }
+            foreach(var summon in player.getPlateController().getPlayerSummons())
+            {
+                summon.UpdateSpecialAttackCooldowns(); // 특수 공격 쿨타임 업데이트
+            }
+
+            player.startTurn();
         }
         else if (currentTurn == Turn.EnermyTurn)  // 적의 턴일 경우
         {
-            enermy.startTurn();
-
             // 적 턴 시작시 아군 소환수 상태이상 및 쿨타임 업데이트
             foreach (var summon in player.getPlateController().getPlayerSummons())
             {
-                summon.UpdateStatusEffectsAndCooldowns(); // 상태이상 업데이트
+                summon.UpdateDamageStatusEffects(); // 데미지를 주는 상태이상 업데이트
+                summon.UpdateStunAndCurseStatus(); // 스턴 및 저주 상태 업데이트
                 summon.getAttackStrategy().ReduceCooldown(); // 일반 공격 쿨타임 감소
             }
+
+            foreach (var summon in enermy.getEnermyAttackController().getPlateController().getEnermySummons())
+            {
+                summon.UpdateSpecialAttackCooldowns(); // 특수 공격 쿨타임 업데이트
+            }
+
+            enermy.startTurn();
         }
     }
 
@@ -56,8 +67,16 @@ public class TurnController : MonoBehaviour
             // 다음 턴을 적의 턴으로 설정
             currentTurn = Turn.EnermyTurn;
 
+            // 적 턴 시작시 아군 소환수 상태이상 및 쿨타임 업데이트
+            foreach (var summon in player.getPlateController().getPlayerSummons())
+            {
+                summon.UpdateUpgradeStatus(); //강화 상태 업데이트
+            }
+
             // 플레이어 턴이 끝나면 턴 카운트를 증가시키지 않고 바로 적 턴 시작
             StartTurn();
+
+
         }
         else if (currentTurn == Turn.EnermyTurn)
         {
@@ -67,6 +86,22 @@ public class TurnController : MonoBehaviour
             turnCount++; // 적 턴이 끝나면 턴 카운트를 증가시킴
             UpdateTurnCountUI();
             player.AddMana();
+
+            //적 턴 끝날때 적 플레이트의 강화를 품
+            foreach (var summon in enermy.getEnermyAttackController().getPlateController().getEnermySummons())
+            {
+                summon.UpdateUpgradeStatus(); //강화 상태 업데이트
+            }
+
+            // 플레이어 턴이 끝날 때 혼란 상태가 아닌 소환수들의 공격 가능 여부를 설정
+            foreach (var summon in player.getPlateController().getPlayerSummons())
+            {
+                if (!summon.IsStun()) // 스턴 상태가 아닌 경우
+                {
+                    summon.setIsAttack(true); // 공격 가능하게 설정
+                }
+            }
+
             Debug.Log("현재 턴: " + turnCount);
 
             StartTurn();

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Enermy.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Enermy.cs
@@ -18,14 +18,14 @@ public class Enermy : Character
         enermyAlgorithm = GetComponent<EnermyAlgorithm>();
     }
 
-    public override void startTurn()
+    public  void startTurn()
     {
-        base.startTurn();
+        Debug.Log("적 턴 시작");
         // 적의 행동을 자동으로 결정함 (예: 플레이어를 공격)
         takeAction();
     }
 
-    public override void takeAction() //여기에 AI로직 작성
+    public  void takeAction() //여기에 AI로직 작성
     {
         //플레이어의 예측공격 리스트를 가져오고
         List<AttackPrediction> playerAttackPredictionsList = enermyAlgorithm.getPlayerAttackPredictionsList();
@@ -39,7 +39,7 @@ public class Enermy : Character
         EndTurn();
     }
 
-    public override void EndTurn()
+    public void EndTurn()
     {
         Debug.Log("적 턴 종료");
         turnController.EndTurn();

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAlgorithm.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAlgorithm.cs
@@ -131,7 +131,7 @@ public class EnermyAlgorithm : MonoBehaviour
 
     private bool reactSpecialFromPoison(Summon attacker, int attackingEnermyPlateIndex, AttackPrediction playerPrediction)
     {
-        IAttackStrategy[] attackStrategy = attacker.getAvailableSpecialAttacks(); // 사용 가능한 스킬들 가져오기
+        IAttackStrategy[] attackStrategy = attacker.getSpecialAttackStrategy(); //해당 소환수의 스킬 가져오기
 
         if (attackStrategy == null)
         {
@@ -142,6 +142,10 @@ public class EnermyAlgorithm : MonoBehaviour
         {
             for (int i = 0; i < attackStrategy.Length; i++)
             {
+                if (attacker.isSpecialAttackCool(attackStrategy[i])) //쿨타임이면 다음 특수스킬 검사
+                {
+                    continue;
+                }
                 if (attackStrategy[i].getStatusType() == StatusType.Heal) //타겟플레이트가 적이 되어야함
                 {
                     int targetPlateIndex = plateController.getLowestHealthEnermyPlateIndex();
@@ -163,7 +167,7 @@ public class EnermyAlgorithm : MonoBehaviour
 
     private bool reactSpecialFromTargetNone(Summon attacker, int attackingEnermyPlateIndex, AttackPrediction playerPrediction)
     {
-        IAttackStrategy[] attackStrategy = attacker.getAvailableSpecialAttacks(); // 사용 가능한 스킬들 가져오기
+        IAttackStrategy[] attackStrategy = attacker.getSpecialAttackStrategy(); //해당 소환수의 스킬 가져오기
 
         if (attackStrategy == null)
         {
@@ -174,6 +178,10 @@ public class EnermyAlgorithm : MonoBehaviour
         {
             for (int i = 0; i < attackStrategy.Length; i++)
             {
+                if (attacker.isSpecialAttackCool(attackStrategy[i])) //쿨타임이면 다음 특수스킬 검사
+                {
+                    continue;
+                }
                 if (attackStrategy[i].getStatusType() == StatusType.Stun)
                 {
                     battleController.SpecialAttackLogic(attacker, playerPrediction.getAttackSummonPlateIndex(), i);
@@ -193,13 +201,6 @@ public class EnermyAlgorithm : MonoBehaviour
                     return true;
                 }
             }
-
-            //// 특수 공격을 실행하지 않은 경우, 일반 공격 실행
-            //if (!specialAttackExecuted)
-            //{
-            //    handleReactNormalAttack(attacker, targetPlateIndex);
-            //    Debug.Log($"{attacker.getSummonName()}가 일반 공격을 실행했습니다."); 
-            //}
         }
         return false;
     }
@@ -207,7 +208,7 @@ public class EnermyAlgorithm : MonoBehaviour
     //전체 공격 대응
     private bool reactSpecialFromAllNone(Summon attacker, int attackingEnermyPlateIndex, AttackPrediction playerPrediction)
     {
-        IAttackStrategy[] attackStrategy = attacker.getAvailableSpecialAttacks(); // 사용 가능한 스킬들 가져오기
+        IAttackStrategy[] attackStrategy = attacker.getSpecialAttackStrategy(); //해당 소환수의 스킬 가져오기
 
         if (attackStrategy == null)
         {
@@ -218,6 +219,10 @@ public class EnermyAlgorithm : MonoBehaviour
         {
             for (int i = 0; i < attackStrategy.Length; i++)
             {
+                if (attacker.isSpecialAttackCool(attackStrategy[i])) //쿨타임이면 다음 특수스킬 검사
+                {
+                    continue;
+                }
                 if (attackStrategy[i].getStatusType() == StatusType.Stun)
                 {
                     battleController.SpecialAttackLogic(attacker, playerPrediction.getAttackSummonPlateIndex(), i); //공격한 대상에게 스턴
@@ -244,7 +249,7 @@ public class EnermyAlgorithm : MonoBehaviour
     }
     private bool reactSpecialFromHeal(Summon attacker, int attackingEnermyPlateIndex, AttackPrediction playerPrediction)
     {
-        IAttackStrategy[] attackStrategy = attacker.getAvailableSpecialAttacks(); // 사용 가능한 스킬들 가져오기
+        IAttackStrategy[] attackStrategy = attacker.getSpecialAttackStrategy(); //해당 소환수의 스킬 가져오기
 
         if (attackStrategy == null)
         {
@@ -255,6 +260,10 @@ public class EnermyAlgorithm : MonoBehaviour
         {
             for (int i = 0; i < attackStrategy.Length; i++)
             {
+                if (attacker.isSpecialAttackCool(attackStrategy[i])) //쿨타임이면 다음 특수스킬 검사
+                {
+                    continue;
+                }
                 if (attackStrategy[i].getStatusType() == StatusType.None && attackStrategy[i] is TargetedAttackStrategy) //타겟공격인지 검사
                 {
                     battleController.SpecialAttackLogic(attacker, playerPrediction.getAttackSummonPlateIndex(), i);
@@ -274,7 +283,7 @@ public class EnermyAlgorithm : MonoBehaviour
     }
     private bool reactSpecialFromUpgrade(Summon attacker, int attackingEnermyPlateIndex, AttackPrediction playerPrediction)
     {
-        IAttackStrategy[] attackStrategy = attacker.getAvailableSpecialAttacks(); // 사용 가능한 스킬들 가져오기
+        IAttackStrategy[] attackStrategy = attacker.getSpecialAttackStrategy(); //해당 소환수의 스킬 가져오기
 
         if (attackStrategy == null)
         {
@@ -285,6 +294,10 @@ public class EnermyAlgorithm : MonoBehaviour
         {
             for (int i = 0; i < attackStrategy.Length; i++)
             {
+                if (attacker.isSpecialAttackCool(attackStrategy[i])) //쿨타임이면 다음 특수스킬 검사
+                {
+                    continue;
+                }
                 if (attackStrategy[i].getStatusType() == StatusType.Curse) //저주공격인지 검사
                 {
                     battleController.SpecialAttackLogic(attacker, playerPrediction.getAttackSummonPlateIndex(), i);
@@ -308,7 +321,7 @@ public class EnermyAlgorithm : MonoBehaviour
 
     private void handleReactNormalAttack(Summon attacker, int attackingEnermyPlateIndex, int targetPlateIndex)
     {
-        IAttackStrategy[] attackStrategy = attacker.getAvailableSpecialAttacks(); // 사용 가능한 스킬들 가져오기
+        IAttackStrategy[] attackStrategy = attacker.getSpecialAttackStrategy(); //해당 소환수의 스킬 가져오기
         float randomValue;
         if (attackStrategy == null)
         {
@@ -332,6 +345,10 @@ public class EnermyAlgorithm : MonoBehaviour
         {
             for (int i = 0; i < attackStrategy.Length; i++)
             {
+                if (attacker.isSpecialAttackCool(attackStrategy[i])) //쿨타임이면 다음 특수스킬 검사
+                {
+                    continue;
+                }
                 if (attackStrategy[i].getStatusType() == StatusType.Upgrade) //강화 공격인지 검사
                 {
                     battleController.SpecialAttackLogic(attacker, targetPlateIndex, i);
@@ -356,6 +373,10 @@ public class EnermyAlgorithm : MonoBehaviour
         {
             for (int i = 0; i < attackStrategy.Length; i++)
             {
+                if (attacker.isSpecialAttackCool(attackStrategy[i])) //쿨타임이면 다음 특수스킬 검사
+                {
+                    continue;
+                }
                 if (attackStrategy[i].getStatusType() == StatusType.Curse)
                 {
                     battleController.SpecialAttackLogic(attacker, targetPlateIndex, i);
@@ -380,6 +401,10 @@ public class EnermyAlgorithm : MonoBehaviour
         {
             for (int i = 0; i < attackStrategy.Length; i++)
             {
+                if (attacker.isSpecialAttackCool(attackStrategy[i])) //쿨타임이면 다음 특수스킬 검사
+                {
+                    continue;
+                }
                 if (attackStrategy[i].getStatusType() == StatusType.LifeDrain) //저주 공격인지 검사
                 {
                     battleController.SpecialAttackLogic(attacker, get30PercentDifferentHP(attacker, plateController.getPlayerPlates()), i);

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Player.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Player.cs
@@ -68,9 +68,9 @@ public class Player : Character
         }
     }
 
-    public override void startTurn()
+    public void startTurn()
     {
-        base.startTurn();
+        Debug.Log("플레이어 턴 시작");
         Debug.Log($"{gameObject.name} 의 마나: {mana}");
         hasSummonedThisTurn = false;
         UpdateManaUI();
@@ -106,7 +106,6 @@ public class Player : Character
         else
         {
             summonFailSound.Play(); // 효과음 재생
-            takeAction();
             Debug.Log("마나가 부족하여 소환 불가능");
         }
     }
@@ -148,6 +147,11 @@ public class Player : Character
     public void OnAttackBtnClick() //일반공격
     {
         Summon attackSummon = battleController.attackStart(0); //공격할 소환수를 받아온다.
+        if (!attackSummon.getIsAttack()) {
+            Debug.Log("공격할 수 없습니다. ");  
+            return; 
+        }
+
         if (attackSummon != null)
         {
             // 일반 공격 수행(플레이트, 공격할 인덱스)
@@ -169,6 +173,11 @@ public class Player : Character
     public void OnSpecialAttackBtnClick() //특수공격
     {
         Summon attackSummon = battleController.attackStart(0); // 공격할 소환수를 가져옴
+        if (!attackSummon.getIsAttack())
+        {
+            Debug.Log("공격할 수 없습니다. ");
+            return;
+        }
 
         if (attackSummon != null)
         {

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs
@@ -2,17 +2,50 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class CatAttackPrediction : MonoBehaviour
+public class CatAttackPrediction : MonoBehaviour, IAttackPrediction
 {
-    private PlateController plateController;
-    private void Awake()
+
+    public SummonType getPreSummonType()
     {
-        plateController = GetComponent<PlateController>();
+        return SummonType.Cat;
+    }
+
+    //고양이 예측공격
+    public AttackPrediction getAttackPrediction(Summon cat, int catPlateIndex, List<Plate> playerPlates, List<Plate> enermyPlates)
+    {
+        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
+        AttackProbability attackProbability = new AttackProbability(50f, 50f);
+        int attackIndex = getClosestEnermyIndex(enermyPlates);
+        AttackPrediction attackPrediction = new AttackPrediction(cat, catPlateIndex, cat.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
+
+        // 일반 공격으로 처치가 가능하면 일반 공격 확률 10% 증가
+        if (getIndexOfNormalAttackCanKill(cat, enermyPlates) != -1)
+        {
+            attackProbability = AdjustAttackProbabilities(attackProbability, 0.1f, true, "고양이 일반공격으로 처치 가능");
+            attackIndex = getIndexOfNormalAttackCanKill(cat, enermyPlates); //일반 공격으로 처치가능한 인덱스 받기
+        }
+        else
+        {
+            // 특수 공격으로 처치가 가능하면 특수 공격 확률 증가
+            if (getIndexOfSpecialCanKill(cat, enermyPlates) != -1)
+            {
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "고양이 특수공격으로 처치가능");
+                attackIndex = getIndexOfSpecialCanKill(cat, enermyPlates); //특수 공격으로 처치가능한 인덱스 받기
+            }
+            else
+            { //특수공격에 +5%
+                attackProbability = AdjustAttackProbabilities(attackProbability, 5f, false, "고양이 특수공격으로 처치 불가능");
+                attackIndex = getClosestEnermyIndex(enermyPlates); //적 플레이트 중에서 가장 가까이 있는 인덱스 받기
+            }
+        }
+
+        attackPrediction = new AttackPrediction(cat, catPlateIndex, cat.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
+        return attackPrediction;
     }
 
 
     // 일반 공격으로 적을 물리칠 수 있는 가장 가까운 인덱스를 반환하는 메소드
-    public int getIndexofNormalAttackCanKill(Summon attackingSummon, List<Plate> enermyPlates)
+    public int getIndexOfNormalAttackCanKill(Summon cat, List<Plate> enermyPlates)
     {
         // 가장 가까운 적의 인덱스를 가져옴
         int closestIndex = getClosestEnermyIndex(enermyPlates);
@@ -21,7 +54,7 @@ public class CatAttackPrediction : MonoBehaviour
         {
             Summon closestEnermySummon = enermyPlates[closestIndex].getCurrentSummon();
             // 가장 가까운 적의 소환수가 있고, 일반 공격으로 물리칠 수 있는지 확인
-            if (closestEnermySummon != null && attackingSummon.getAttackPower() >= closestEnermySummon.getNowHP())
+            if (closestEnermySummon != null && cat.getAttackPower() >= closestEnermySummon.getNowHP())
             {
                 return closestIndex; // 공격으로 물리칠 수 있으면 인덱스 반환
             }
@@ -31,12 +64,12 @@ public class CatAttackPrediction : MonoBehaviour
     }
 
     //특수스킬로 죽일 수 있는 인덱스 반환
-    public int getIndexofSpecialCanKill(Summon attackingSummon, List<Plate> enermyPlates)
+    public int getIndexOfSpecialCanKill(Summon cat, List<Plate> enermyPlates)
     {
         for (int i = 0; i < enermyPlates.Count; i++)
         {
             Summon enermySummon = enermyPlates[i].getCurrentSummon();
-            if (enermySummon != null && attackingSummon.getAttackPower() >= enermySummon.getNowHP())
+            if (enermySummon != null && cat.getAttackPower() >= enermySummon.getNowHP())
             {
                 // 일반 공격으로 적의 체력을 0 이하로 만들 수 있으면 해당 인덱스 반환
                 return i;
@@ -57,6 +90,26 @@ public class CatAttackPrediction : MonoBehaviour
             }
         }
         return -1; // 적 소환수가 없으면 -1 반환
+    }
+
+    // 확률 값을 설정하고 조정하여 반환하는 메소드
+    private AttackProbability AdjustAttackProbabilities(AttackProbability currentProbabilities, float AttackChange, bool isNormalAttack, string reason)
+    {
+        if (isNormalAttack)
+        {
+            // 일반 공격 확률을 증가시키고, 특수 공격 확률을 그만큼 감소
+            currentProbabilities.normalAttackProbability += AttackChange;
+            currentProbabilities.specialAttackProbability -= AttackChange;
+            Debug.Log($"일반 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+        }
+        else
+        {
+            // 특수 공격 확률을 증가시키고, 일반 공격 확률을 그만큼 감소
+            currentProbabilities.specialAttackProbability += AttackChange;
+            currentProbabilities.normalAttackProbability -= AttackChange;
+            Debug.Log($"특수 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+        }
+        return currentProbabilities;
     }
 
 }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/EagleAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/EagleAttackPrediction.cs
@@ -2,14 +2,74 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class EagleAttackPrediction : MonoBehaviour
+public class EagleAttackPrediction : MonoBehaviour, IAttackPrediction
 {
 
-    private PlateController plateController;
-
-    private void Awake()
+    public SummonType getPreSummonType()
     {
-        plateController = GetComponent<PlateController>();
+        return SummonType.Eagle;
+    }
+
+
+    //독수리 예측공격
+    public AttackPrediction getAttackPrediction(Summon eagle, int eaglePlateIndex, List<Plate> playerPlates, List<Plate> enermyPlates)
+    {
+        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
+        AttackProbability attackProbability = new AttackProbability(50f, 50f);
+        int attackIndex = getClosestEnermyIndex(enermyPlates); //가장 가까운적의 인덱스 기본값
+
+
+        if (isTwoOrMoreEnemies(enermyPlates)) //적이 2마리 이상인가?
+        {
+            if (isEnermyHealthDifferenceOver30(enermyPlates)) //몬스터 한 쪽이 다른쪽과 비교했을 때 30% 이상 낮은가?
+            {
+                if (getIndexOfNormalAttackCanKill(eagle, enermyPlates) != -1) //일반 공격으로 체력이 낮은 쪽을 공격할 수 있는가?
+                {
+                    attackIndex = getIndexOfNormalAttackCanKill(eagle, enermyPlates);
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "독수리 일반공격으로 체력이 낮은 적 공격 가능");
+                }
+                else
+                {
+                    attackIndex = getSpecialAttackKillIndex(eagle, enermyPlates);
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "독수리 일반공격으로 체력이 낮은쪽 공격 불가능");
+                }
+            }
+            else if (AreEnermyHealthWithin10Percent(enermyPlates)) //몬스터의 체력이 서로 비슷한가?
+            {
+                if (getIndexOfMostHealthEnermy(enermyPlates) != -1) //가장 체력이 많은 몬스터의 인덱스
+                {
+                    attackIndex = getIndexOfMostHealthEnermy(enermyPlates);
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "독수리 몬스터 체력이 10퍼이내로 비슷함");
+                }
+            }
+        }
+        else if (isOnlyOneEnemy(enermyPlates)) //적이 1마리 인가?
+        {
+            if (getIndexOfNormalAttackCanKill(eagle, enermyPlates) != -1)
+            {
+                attackIndex = getIndexOfNormalAttackCanKill(eagle, enermyPlates);
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "독수리 일반공격으로 사냥가능");
+            }
+            else if (getSpecialAttackKillIndex(eagle, enermyPlates) != -1)
+            {
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "독수리 특수공격으로 사냥가능");
+            }
+            else
+            {
+                if (getTypeOfMoreAttackDamage(eagle, enermyPlates) == AttackType.NormalAttack)//일반공격과 특수공격 중 피해를 많이 줄 공격에 5%상승
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, true, "독수리 일반공격이 더 큰 피해를 입힘");
+                }
+                else
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, false, "독수리 일반공격이 더 큰 피해를 입힘");
+                }
+            }
+        }
+
+        //소환수, 소환수의 플레이트 번호, 소환수의 특수공격첫번째, 특수공격배열 인덱스번호, 타겟플레이트, 타겟플레이트 변호, 확률
+        AttackPrediction attackPrediction = new AttackPrediction(eagle, eaglePlateIndex, eagle.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
+        return attackPrediction;
     }
 
 
@@ -142,12 +202,16 @@ public class EagleAttackPrediction : MonoBehaviour
     // 특수 공격으로 공격할 수 있는지 확인하고, 공격 가능한 인덱스를 반환하는 메소드
     public int getSpecialAttackKillIndex(Summon eagle, List<Plate> enermyPlates)
     {
-        foreach (IAttackStrategy specialAttack in eagle.getAvailableSpecialAttacks())
+        for(int i=0; i< eagle.getSpecialAttackStrategy().Length; i++)
         {
-            for (int i = 0; i < enermyPlates.Count; i++)
+            if (eagle.isSpecialAttackCool(eagle.getSpecialAttackStrategy()[i]))
             {
-                Summon enermySummon = enermyPlates[i].getCurrentSummon();
-                if (enermySummon != null && specialAttack.getSpecialDamage() >= enermySummon.getNowHP())
+                continue;
+            }
+            for (int ii = 0; ii < enermyPlates.Count; ii++)
+            {
+                Summon enermySummon = enermyPlates[ii].getCurrentSummon();
+                if (enermySummon != null && eagle.getSpecialAttackStrategy()[i].getSpecialDamage() >= enermySummon.getNowHP())
                 {
                     return i; // 특수 공격으로 처치 가능한 인덱스 반환
                 }
@@ -157,7 +221,7 @@ public class EagleAttackPrediction : MonoBehaviour
     }
 
     // 가장 가까운 적을 공격했을 때 물리칠 수 있는지 확인하고, 공격 가능한 인덱스를 반환하는 메소드
-    public int getNormalAttackKillIndex(Summon eagle, List<Plate> enermyPlates)
+    public int getIndexOfNormalAttackCanKill(Summon eagle, List<Plate> enermyPlates)
     {
         int closestIndex = getClosestEnermyIndex(enermyPlates);
         if (closestIndex != -1)
@@ -182,5 +246,25 @@ public class EagleAttackPrediction : MonoBehaviour
             }
         }
         return -1; // 적 소환수가 없으면 -1 반환
+    }
+
+    // 확률 값을 설정하고 조정하여 반환하는 메소드
+    private AttackProbability AdjustAttackProbabilities(AttackProbability currentProbabilities, float AttackChange, bool isNormalAttack, string reason)
+    {
+        if (isNormalAttack)
+        {
+            // 일반 공격 확률을 증가시키고, 특수 공격 확률을 그만큼 감소
+            currentProbabilities.normalAttackProbability += AttackChange;
+            currentProbabilities.specialAttackProbability -= AttackChange;
+            Debug.Log($"일반 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+        }
+        else
+        {
+            // 특수 공격 확률을 증가시키고, 일반 공격 확률을 그만큼 감소
+            currentProbabilities.specialAttackProbability += AttackChange;
+            currentProbabilities.normalAttackProbability -= AttackChange;
+            Debug.Log($"특수 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+        }
+        return currentProbabilities;
     }
 }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/FoxAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/FoxAttackPrediction.cs
@@ -2,13 +2,75 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class FoxAttackPrediction : MonoBehaviour
+public class FoxAttackPrediction : MonoBehaviour, IAttackPrediction
 {
-    private PlateController plateController;
 
-    private void Awake()
+    public SummonType getPreSummonType()
     {
-        plateController = GetComponent<PlateController>();
+        return SummonType.Rabbit;
+    }
+
+    //여우 예측공격
+    public AttackPrediction getAttackPrediction(Summon fox, int foxPlateIndex, List<Plate> playerPlates, List<Plate> enermyPlates)
+    {
+        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
+        AttackProbability attackProbability = new AttackProbability(50f, 50f);
+        int attackIndex = getClosestEnermyIndex(enermyPlates);
+        List<Plate> targetPlate = enermyPlates;
+
+        //소환수, 소환수의 플레이트 번호, 소환수의 특수공격첫번째, 특수공격배열 인덱스번호, 타겟플레이트, 타겟플레이트 변호, 확률
+        AttackPrediction attackPrediction = new AttackPrediction(fox, foxPlateIndex, fox.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
+
+
+        if (getIndexOfSummonWithCurseStatus(playerPlates) != -1) //소환수중 저주상태에 걸려있는 몹이 있는가?
+        {
+            attackProbability = new AttackProbability(0f, 100f); //특수공격 100%
+            attackIndex = getIndexOfSummonWithCurseStatus(playerPlates);
+            attackPrediction = new AttackPrediction(fox, foxPlateIndex, fox.getSpecialAttackStrategy()[0], 0, playerPlates, attackIndex, attackProbability);
+        }
+        else if (isTwoOrMoreEnemies(enermyPlates)) //적이 2마리 이상 존재하는가?
+        {
+            if (AllEnemiesHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
+            {
+                if (AllSummonsLowOrMediumRank(playerPlates)) //아군의 등급이 모두 하급과 중급인가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "여우 아군 등급이 모두 하급과 중급");
+                    targetPlate = playerPlates;
+                }
+            }
+            else if (isAnyEnemyHealthDown30Percent(enermyPlates)) //적의 체력이 하나만 30% 아래인가
+            {
+                if (getIndexOfNormalAttackCanKill(fox, enermyPlates) != -1) //일반공격시 처치할 수 있는가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "여우 일반공격시 처치가능");
+                }
+            }
+        }
+        else if (isOnlyOneEnemy(enermyPlates)) //적이 1마리 인가?
+        {
+            if (isAnyEnemyHealthOver70Percent(enermyPlates)) //적의 체력이 70% 이상인가?
+            {
+                if (AllSummonsLowOrMediumRank(playerPlates)) //아군의 등급이 모두 하급과 중급인가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "여우 아군 등급이 모두 하급과 중급");
+                    targetPlate = playerPlates;
+                }
+            }
+            else if (getIndexOfNormalAttackCanKill(fox, enermyPlates) != -1) //일반공격시 몬스터를 물리칠 수 있는가?
+            {
+                if (getIndexOfNormalAttackCanKill(fox, enermyPlates) != -1) //일반공격시 처치할 수 있는가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "여우 일반공격시 가까운적 처치 가능");
+                }
+            }
+        }
+        else
+        {
+            attackIndex = getIndexOfHighestAttackPower(playerPlates);
+            attackPrediction = new AttackPrediction(fox, foxPlateIndex, fox.getSpecialAttackStrategy()[0], 0, playerPlates, attackIndex, attackProbability);
+        }
+
+        return attackPrediction;
     }
 
     // 소환수 중 저주 상태 이상에 걸려있는 몹이 존재하는가?
@@ -130,18 +192,22 @@ public class FoxAttackPrediction : MonoBehaviour
 
 
     // 가장 가까운 적을 공격했을 때 물리칠 수 있는지 확인하는 메소드
-    public bool CanNormalAttackKill(Summon fox, List<Plate> enermyPlates)
+    public int getIndexOfNormalAttackCanKill(Summon fox, List<Plate> enermyPlates)
     {
+        // 가장 가까운 적의 인덱스를 가져옴
         int closestIndex = getClosestEnermyIndex(enermyPlates);
+
         if (closestIndex != -1)
         {
             Summon closestEnermySummon = enermyPlates[closestIndex].getCurrentSummon();
+            // 가장 가까운 적의 소환수가 있고, 일반 공격으로 물리칠 수 있는지 확인
             if (closestEnermySummon != null && fox.getAttackPower() >= closestEnermySummon.getNowHP())
             {
-                return true; // 가장 가까운 적을 일반 공격으로 처치할 수 있으면 true 반환
+                return closestIndex; // 공격으로 물리칠 수 있으면 인덱스 반환
             }
         }
-        return false; // 처치할 수 없으면 false 반환
+
+        return -1; // 공격 가능한 적이 없으면 -1 반환
     }
 
     public int getClosestEnermyIndex(List<Plate> enermyPlates)
@@ -155,5 +221,25 @@ public class FoxAttackPrediction : MonoBehaviour
             }
         }
         return -1; // 적 소환수가 없으면 -1 반환
+    }
+
+    // 확률 값을 설정하고 조정하여 반환하는 메소드
+    private AttackProbability AdjustAttackProbabilities(AttackProbability currentProbabilities, float AttackChange, bool isNormalAttack, string reason)
+    {
+        if (isNormalAttack)
+        {
+            // 일반 공격 확률을 증가시키고, 특수 공격 확률을 그만큼 감소
+            currentProbabilities.normalAttackProbability += AttackChange;
+            currentProbabilities.specialAttackProbability -= AttackChange;
+            Debug.Log($"일반 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+        }
+        else
+        {
+            // 특수 공격 확률을 증가시키고, 일반 공격 확률을 그만큼 감소
+            currentProbabilities.specialAttackProbability += AttackChange;
+            currentProbabilities.normalAttackProbability -= AttackChange;
+            Debug.Log($"특수 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+        }
+        return currentProbabilities;
     }
 }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/IAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/IAttackPrediction.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.Burst.Intrinsics;
+using UnityEngine;
+
+public interface IAttackPrediction
+{
+    int getIndexOfNormalAttackCanKill(Summon attackingSummon, List<Plate> enermyPlates);
+    int getClosestEnermyIndex(List<Plate> enermyPlates);
+
+    public AttackPrediction getAttackPrediction(Summon summon, int attackSummonPlateIndex, List<Plate> playerPlates, List<Plate> enermyPlates);
+
+    SummonType getPreSummonType();
+}

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/IAttackPrediction.cs.meta
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/IAttackPrediction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43b3b64ccf7439d4ebc0e8465cc197f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/PlayerAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/PlayerAttackPrediction.cs
@@ -6,33 +6,21 @@ using UnityEngine;
 public class PlayerAttackPrediction : MonoBehaviour
 {
     private PlateController plateController;
+    private List<IAttackPrediction> attackPredictions;
 
-
-    private CatAttackPrediction catAttackPrediction;
-    private FoxAttackPrediction foxAttackPrediction;
-    private WolfAttackPrediction wolfAttackPrediction;
-    private EagleAttackPrediction eagleAttackPrediction;
-    private SnakeAttackPrediction snakeAttackPrediction;
-    private RabbitAttackPrediction rabbitAttackPrediction;
     private void Awake()
     {
         plateController = GetComponent<PlateController>();
-        catAttackPrediction = GetComponent<CatAttackPrediction>();
-        foxAttackPrediction = GetComponent<FoxAttackPrediction>();
-        wolfAttackPrediction = GetComponent<WolfAttackPrediction>();
-        eagleAttackPrediction = GetComponent<EagleAttackPrediction>();
-        snakeAttackPrediction = GetComponent<SnakeAttackPrediction>();
-        rabbitAttackPrediction = GetComponent<RabbitAttackPrediction>();
+        attackPredictions = new List<IAttackPrediction>(GetComponents<IAttackPrediction>());
     }
 
-    public List<AttackPrediction> getPlayerAttackPredictionList(List<Plate>playerPlates, List<Plate>enermyPlates) //플레이어의 행동예측 반환
+    public List<AttackPrediction> getPlayerAttackPredictionList(List<Plate> playerPlates, List<Plate> enermyPlates)
     {
         List<AttackPrediction> playerPrediction = new List<AttackPrediction>();
 
         foreach (Plate plate in playerPlates)
         {
             Summon summon = plate.getCurrentSummon();
-
             if (summon != null)
             {
                 // 소환수의 특수 스킬이 사용 가능한지 확인
@@ -52,7 +40,7 @@ public class PlayerAttackPrediction : MonoBehaviour
                     AttackProbability attackProbability = new AttackProbability(100f, 0f); //일반공격을 100%
 
                     AttackPrediction attackPrediction = new AttackPrediction(
-                        summon, //공격
+                        summon, //공격하는 소환수
                         plateController.GetPlateIndex(plate), //자기 자신의 플레이트 번호
                         summon.getAttackStrategy(), //일반공격
                         0, //특수공격 번호
@@ -60,66 +48,24 @@ public class PlayerAttackPrediction : MonoBehaviour
                         attackIndex, ///타겟 번호
                         attackProbability //확률
                         );
-             
+
                     playerPrediction.Add(attackPrediction);
                     Debug.Log($"추가된 일반공격 Prediction: {GetPredictionDetails(attackPrediction)}");
                 }
                 else
                 {
-                    // 소환수에 따라 예측공격 수행
-                    switch (summon.getSummonType())
+                    // 적절한 예측 클래스를 찾아서 공격 예측 수행
+                    foreach (IAttackPrediction prediction in attackPredictions)
                     {
-                        case SummonType.Cat:
-                            AttackPrediction catPrediction = getCatAttackPrediction(summon, attackSummonPlateIndex, enermyPlates);
-                            if (catPrediction != null)
+                        if (prediction.getPreSummonType() == summon.getSummonType())
+                        {
+                            AttackPrediction result = prediction.getAttackPrediction(summon, attackSummonPlateIndex, playerPlates, enermyPlates);
+                            if (result != null)
                             {
-                                playerPrediction.Add(catPrediction);
-                                Debug.Log($"추가된 고양이 Prediction: {GetPredictionDetails(catPrediction)}");
+                                playerPrediction.Add(result);
+                                Debug.Log($"추가된 Prediction: {GetPredictionDetails(result)}");
                             }
-                            break;
-                        case SummonType.Wolf:
-                            AttackPrediction wolfPrediction = getWolfAttackPrediction(summon, attackSummonPlateIndex, enermyPlates);
-                            if (wolfPrediction != null)
-                            {
-                                playerPrediction.Add(wolfPrediction);
-                                Debug.Log($"추가된 늑대 Prediction: {GetPredictionDetails(wolfPrediction)}");
-                            }
-                            break;
-                        case SummonType.Snake:
-                            AttackPrediction snakePrediction = getSnakeAttackPrediction(summon, attackSummonPlateIndex, enermyPlates);
-                            if (snakePrediction != null)
-                            {
-                                playerPrediction.Add(snakePrediction);
-                                Debug.Log($"추가된 뱀 Prediction: {GetPredictionDetails(snakePrediction)}");
-                            }
-                            break;
-
-                        case SummonType.Rabbit:
-                            AttackPrediction rabitPrediction = getRabbitAttackPrediction(summon, attackSummonPlateIndex, playerPlates, enermyPlates);
-                            if (rabitPrediction != null)
-                            {
-                                playerPrediction.Add(rabitPrediction);
-                                Debug.Log($"추가된 토끼 Prediction: {GetPredictionDetails(rabitPrediction)}");
-                            }
-                            break;
-
-                        case SummonType.Eagle:
-                            AttackPrediction eaglePrediction = getEagleAttackPrediction(summon, attackSummonPlateIndex, enermyPlates);
-                            if (eaglePrediction != null)
-                            {
-                                playerPrediction.Add(eaglePrediction);
-                                Debug.Log($"추가된 독수리 Prediction: {GetPredictionDetails(eaglePrediction)}");
-                            }
-                            break;
-
-                        case SummonType.Fox:
-                            AttackPrediction foxPrediction = getFoxAttackPrediction(summon, attackSummonPlateIndex,  playerPlates, enermyPlates);
-                            if (foxPrediction != null)
-                            {
-                                playerPrediction.Add(foxPrediction);
-                                Debug.Log($"추가된 여우 Prediction: {GetPredictionDetails(foxPrediction)}");
-                            }
-                            break;
+                        }
                     }
                 }
             }
@@ -128,342 +74,6 @@ public class PlayerAttackPrediction : MonoBehaviour
         return playerPrediction;
     }
 
-
-    //고양이 예측공격
-    private AttackPrediction getCatAttackPrediction(Summon cat, int catPlateIndex ,List<Plate> enermyPlates)
-    {
-        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
-        AttackProbability attackProbability = new AttackProbability(50f, 50f);
-        int attackIndex = catAttackPrediction.getClosestEnermyIndex(enermyPlates);
-        AttackPrediction attackPrediction = new AttackPrediction(cat, catPlateIndex, cat.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
-
-        // 일반 공격으로 처치가 가능하면 일반 공격 확률 10% 증가
-        if (catAttackPrediction.getIndexofNormalAttackCanKill(cat, enermyPlates) != -1)
-        {
-            attackProbability = AdjustAttackProbabilities(attackProbability, 0.1f, true,"고양이 일반공격으로 처치 가능");
-            attackIndex = catAttackPrediction.getIndexofNormalAttackCanKill(cat, enermyPlates); //일반 공격으로 처치가능한 인덱스 받기
-        }
-        else
-        {
-            // 특수 공격으로 처치가 가능하면 특수 공격 확률 증가
-            if (catAttackPrediction.getIndexofSpecialCanKill(cat, enermyPlates) != -1)
-            {
-                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"고양이 특수공격으로 처치가능");
-                attackIndex = catAttackPrediction.getIndexofSpecialCanKill(cat, enermyPlates); //특수 공격으로 처치가능한 인덱스 받기
-            }
-            else
-            { //특수공격에 +5%
-                attackProbability = AdjustAttackProbabilities(attackProbability, 5f, false,"고양이 특수공격으로 처치 불가능");
-                attackIndex = catAttackPrediction.getClosestEnermyIndex(enermyPlates); //적 플레이트 중에서 가장 가까이 있는 인덱스 받기
-            }
-        }
-
-        attackPrediction = new AttackPrediction(cat, catPlateIndex, cat.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
-        return attackPrediction;
-    }
-
-    //늑대의 예측공격
-    private AttackPrediction getWolfAttackPrediction(Summon wolf, int wolfPlateIndex, List<Plate> enermyPlates)
-    {
-        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
-        AttackProbability attackProbability = new AttackProbability(50f, 50f);
-        int attackIndex = wolfAttackPrediction.getClosestEnermyIndex(enermyPlates);
-        AttackPrediction attackPrediction = new AttackPrediction(wolf, wolfPlateIndex, wolf.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
-
-        if (wolfAttackPrediction.IsEnermyCountTwoOrMore(enermyPlates)) //적이 2마리 이상인가?
-        {
-            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"늑대 적이 2마리 이상");
-            if (wolfAttackPrediction.AllEnermyHealthOver50(enermyPlates)) //몬스터 체력이 모두 50% 이상인가?
-            {
-                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"늑대 적 몬스터 체력이 모두 50% 이상");
-            }
-            else if(wolfAttackPrediction.AllEnermyHealthDown50(enermyPlates)) //몬스터 체력이 모두 50% 이하인가?
-            {
-                if (wolfAttackPrediction.HasSpecificAvailableSpecialAttack(wolf, enermyPlates))
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"늑대 적 몬스터 체력이 모두 50% 이하");
-                }
-            }
-            else if (wolfAttackPrediction.IsEnermyHealthDifferenceOver30(enermyPlates)) //몬스터 한쪽이 다른 쪽에비해 체력이 30% 높은가?
-            {
-                if (wolfAttackPrediction.IsLowestHealthEnermyClosest(wolf, enermyPlates)) //낮은쪽의 인덱스가 근접공격하는 인덱스와 동일한가?
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 20f, true,"늑대 낮은쪽으로 공격하는 인덱스가 동일");
-                }
-                else
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"늑대 일반공격으로 공격하는 인덱스가 불일치");
-                }
-            }
-        }
-        else if(wolfAttackPrediction.IsEnermyCountOne(enermyPlates)) //적이 1마리 인가?
-        {
-            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true,"늑대 적이 1마리뿐");
-            
-            if(wolfAttackPrediction.getIndexofNormalAttackCanKill(wolf,enermyPlates) != -1) //일반 공격으로 몬스터를 물리칠 수 있는가?
-            {
-                attackIndex = wolfAttackPrediction.getIndexofNormalAttackCanKill(wolf, enermyPlates);
-                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true,"늑대 일반 공격으로 처치가능");
-            }
-            else
-            {
-                //일반 공격과 특수공격중 피해를 더 줄 수 있는 공격을 반환했을 때 일반 공격일경우
-                if (wolfAttackPrediction.getMostDamageAttack(wolf, enermyPlates) == AttackType.NormalAttack)
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, true,"늑대 일반 공격이 더 많은 피해를 입힘");
-                }
-                else
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, false,"늑대 특수공격이 더 많은 피해를 입힘");
-                }
-            }
-        }
-
-        attackPrediction = new AttackPrediction(wolf, wolfPlateIndex, wolf.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
-        return attackPrediction;
-    }
-
-
-    //토끼의 예측공격
-    private AttackPrediction getRabbitAttackPrediction(Summon rabbit, int rabbitPlateIndex, List<Plate> playerPlates, List<Plate> enermyPlates)
-    {
-        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
-        AttackProbability attackProbability = new AttackProbability(50f, 50f);
-        int attackIndex = rabbitAttackPrediction.getClosestEnermyIndex(enermyPlates);
-        AttackPrediction attackPrediction = new AttackPrediction(rabbit, rabbitPlateIndex, rabbit.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
-
-        if (rabbitAttackPrediction.GetIndexOfLowerHealthIfDifferenceOver30(playerPlates) != -1) //소환수 중 한쪽이 다른 쪽과 체력을 비교했을 때 30% 이상 낮은가?
-        {
-            attackIndex = rabbitAttackPrediction.GetIndexOfLowerHealthIfDifferenceOver30(playerPlates);
-            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"토끼 소환수중 한쪽이 다른 쪽과 비교할때 30% 낮음");
-            attackPrediction = new AttackPrediction(rabbit, rabbitPlateIndex, rabbit.getSpecialAttackStrategy()[0], 0, playerPlates, attackIndex, attackProbability);
-        }
-        else if (rabbitAttackPrediction.getIndexOfLowerHealthIfAllDown30(playerPlates) != -1) //소환수 모두의 체력이 30% 이하인가?
-        {
-            attackIndex = rabbitAttackPrediction.getIndexOfLowerHealthIfAllDown30(playerPlates);
-            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"토끼 소환수의 체력이 모두 30% 이하");
-            attackPrediction = new AttackPrediction(rabbit, rabbitPlateIndex, rabbit.getSpecialAttackStrategy()[0], 0, playerPlates, attackIndex, attackProbability);
-        }
-        else if (rabbitAttackPrediction.AllPlayerSummonOver70Percent(playerPlates))
-        {
-            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true,"토끼 모든 플레이어 소환수 체력이 70% 이상");
-            attackIndex = rabbitAttackPrediction.getIndexOfLowestHealthSummon(playerPlates);
-            attackPrediction = new AttackPrediction(rabbit, rabbitPlateIndex, rabbit.getSpecialAttackStrategy()[0], 0, playerPlates, attackIndex, attackProbability);
-        }
-        else if (rabbitAttackPrediction.CanNormalAttackKill(rabbit, enermyPlates))
-        {
-            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true,"토끼 일반공격으로 처치가능");
-            attackIndex = rabbitAttackPrediction.getIndexOfLowestHealthSummon(playerPlates);
-            attackPrediction = new AttackPrediction(rabbit, rabbitPlateIndex, rabbit.getSpecialAttackStrategy()[0], 0, playerPlates, attackIndex, attackProbability);
-        }
-        else// 모두 조건이 안맞으면 가장 낮은 체력 아군 힐
-        {
-            attackIndex = rabbitAttackPrediction.getIndexOfLowestHealthSummon(playerPlates);
-            attackPrediction = new AttackPrediction(rabbit, rabbitPlateIndex, rabbit.getSpecialAttackStrategy()[0], 0, playerPlates, attackIndex, attackProbability);
-        }
-
-
-        return attackPrediction;
-    }
-
-
-    //뱀 예측공격
-    private AttackPrediction getSnakeAttackPrediction(Summon snake, int snakePlateIndex, List<Plate> enermyPlates)
-    {
-        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
-        AttackProbability attackProbability = new AttackProbability(50f, 50f);
-        int attackIndex = snakeAttackPrediction.getClosestEnermyIndex(enermyPlates);
-        AttackPrediction attackPrediction = new AttackPrediction(snake, snakePlateIndex, snake.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
-
-        if (snakeAttackPrediction.IsEnermyAlreadyPoisoned(enermyPlates)){ //몬스터들이 이미 중독 상태인가?
-            attackProbability = new AttackProbability(100f, 0f);
-            attackPrediction = new AttackPrediction(snake, snakePlateIndex, snake.getAttackStrategy(), 0, enermyPlates, attackIndex, attackProbability); //일반공격으로
-        }
-        else if(!snakeAttackPrediction.canUseSpecialAttack(snake)) //특수공격을 사용할 수 있는가?
-        {
-            attackProbability = new AttackProbability(100f, 0f);
-            attackPrediction = new AttackPrediction(snake, snakePlateIndex, snake.getAttackStrategy(), 0, enermyPlates, attackIndex, attackProbability); //일반공격으로
-        }
-        else
-        {
-            if (snakeAttackPrediction.isEnermyCountOverTwo(enermyPlates)) //적이 2마리 이상인가?
-            {
-                if (snakeAttackPrediction.AllEnermyHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"뱀 적의 체력이 모두 50%이상");
-                }
-                else
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true,"뱀 적의 체력이 모두 50%가 아님");
-                }
-                if (snakeAttackPrediction.hasMonsterWithMoreThan4Attacks(enermyPlates)) //몬스터 중 공격의 개수가 4개 이상인 몹이 존재하는가?
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"뱀 적의 몬스터중 공격이 4개 이상인 몹이 있는가");
-                }
-            }
-            else //1마리 일때
-            {
-                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true,"뱀 적이 1마리 뿐");
-                if (snakeAttackPrediction.AllEnermyHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "뱀 적의 체력이 모두 50% 이상");
-                }
-                if (snakeAttackPrediction.CanNormalAttackKill(snake, enermyPlates)) //일반 공격 시 몬스터를 물리칠 수 있는가?
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true,"뱀 일반 공격시 처치가능");
-                }
-            }
-            attackPrediction = new AttackPrediction(snake, snakePlateIndex, snake.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
-        }
-
-        return attackPrediction;
-    }
-
-    //여우 예측공격
-    private AttackPrediction getFoxAttackPrediction(Summon fox, int foxPlateIndex, List<Plate> playerPlates, List<Plate> enermyPlates)
-    {
-        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
-        AttackProbability attackProbability = new AttackProbability(50f, 50f);
-        int attackIndex = foxAttackPrediction.getClosestEnermyIndex(enermyPlates);
-        List<Plate> targetPlate = enermyPlates;
-
-        //소환수, 소환수의 플레이트 번호, 소환수의 특수공격첫번째, 특수공격배열 인덱스번호, 타겟플레이트, 타겟플레이트 변호, 확률
-        AttackPrediction attackPrediction = new AttackPrediction(fox, foxPlateIndex, fox.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
-
-
-        if (foxAttackPrediction.getIndexOfSummonWithCurseStatus(playerPlates) != -1) //소환수중 저주상태에 걸려있는 몹이 있는가?
-        {
-            attackProbability = new AttackProbability(0f, 100f); //특수공격 100%
-            attackIndex = foxAttackPrediction.getIndexOfSummonWithCurseStatus(playerPlates);
-            attackPrediction = new AttackPrediction(fox, foxPlateIndex, fox.getSpecialAttackStrategy()[0], 0, playerPlates, attackIndex, attackProbability);
-        }
-        else if(foxAttackPrediction.isTwoOrMoreEnemies(enermyPlates)) //적이 2마리 이상 존재하는가?
-        {
-            if (foxAttackPrediction.AllEnemiesHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
-            {
-                if (foxAttackPrediction.AllSummonsLowOrMediumRank(playerPlates)) //아군의 등급이 모두 하급과 중급인가?
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"여우 아군 등급이 모두 하급과 중급");
-                    targetPlate = playerPlates;
-                }
-            }
-            else if (foxAttackPrediction.isAnyEnemyHealthDown30Percent(enermyPlates)) //적의 체력이 하나만 30% 아래인가
-            {
-                if (foxAttackPrediction.CanNormalAttackKill(fox, enermyPlates)) //일반공격시 처치할 수 있는가?
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true,"여우 일반공격시 처치가능");
-                }
-            }
-        }
-        else if(foxAttackPrediction.isOnlyOneEnemy(enermyPlates)) //적이 1마리 인가?
-        {
-            if (foxAttackPrediction.isAnyEnemyHealthOver70Percent(enermyPlates)) //적의 체력이 70% 이상인가?
-            {
-                if (foxAttackPrediction.AllSummonsLowOrMediumRank(playerPlates)) //아군의 등급이 모두 하급과 중급인가?
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"여우 아군 등급이 모두 하급과 중급");
-                    targetPlate = playerPlates;
-                }
-            }
-            else if(foxAttackPrediction.CanNormalAttackKill(fox, enermyPlates)) //일반공격시 몬스터를 물리칠 수 있는가?
-            {
-                if (foxAttackPrediction.CanNormalAttackKill(fox, enermyPlates)) //일반공격시 처치할 수 있는가?
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true,"여우 일반공격시 가까운적 처치 가능");
-                }
-            }
-        }
-        else
-        {
-            attackIndex = foxAttackPrediction.getIndexOfHighestAttackPower(playerPlates);
-            attackPrediction = new AttackPrediction(fox, foxPlateIndex, fox.getSpecialAttackStrategy()[0], 0, playerPlates, attackIndex, attackProbability);
-        }
-
-        return attackPrediction;
-    }
-
-
-    //독수리 예측공격
-    private AttackPrediction getEagleAttackPrediction(Summon eagle,int eaglePlateIndex, List<Plate> enermyPlates)
-    {
-        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
-        AttackProbability attackProbability = new AttackProbability(50f, 50f);
-        int attackIndex = eagleAttackPrediction.getClosestEnermyIndex(enermyPlates); //가장 가까운적의 인덱스 기본값
-
-
-        if (eagleAttackPrediction.isTwoOrMoreEnemies(enermyPlates)) //적이 2마리 이상인가?
-        {
-            if (eagleAttackPrediction.isEnermyHealthDifferenceOver30(enermyPlates)) //몬스터 한 쪽이 다른쪽과 비교했을 때 30% 이상 낮은가?
-            {
-                if (eagleAttackPrediction.getNormalAttackKillIndex(eagle, enermyPlates) != -1) //일반 공격으로 체력이 낮은 쪽을 공격할 수 있는가?
-                {
-                    attackIndex = eagleAttackPrediction.getNormalAttackKillIndex(eagle, enermyPlates);
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true,"독수리 일반공격으로 체력이 낮은 적 공격 가능");
-                }
-                else
-                {
-                    attackIndex = eagleAttackPrediction.getSpecialAttackKillIndex(eagle, enermyPlates);
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false,"독수리 일반공격으로 체력이 낮은쪽 공격 불가능");
-                }
-            }
-            else if (eagleAttackPrediction.AreEnermyHealthWithin10Percent(enermyPlates)) //몬스터의 체력이 서로 비슷한가?
-            {
-                if (eagleAttackPrediction.getIndexOfMostHealthEnermy(enermyPlates) != -1) //가장 체력이 많은 몬스터의 인덱스
-                {
-                    attackIndex = eagleAttackPrediction.getIndexOfMostHealthEnermy(enermyPlates);
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "독수리 몬스터 체력이 10퍼이내로 비슷함");
-                }
-            }
-        }
-        else if (eagleAttackPrediction.isOnlyOneEnemy(enermyPlates)) //적이 1마리 인가?
-        {
-            if (eagleAttackPrediction.getNormalAttackKillIndex(eagle, enermyPlates) != -1)
-            {
-                attackIndex = eagleAttackPrediction.getNormalAttackKillIndex(eagle, enermyPlates);
-                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "독수리 일반공격으로 사냥가능");
-            }
-            else if (eagleAttackPrediction.getSpecialAttackKillIndex(eagle, enermyPlates) != -1)
-            {
-                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "독수리 특수공격으로 사냥가능");
-            }
-            else
-            {
-                if(eagleAttackPrediction.getTypeOfMoreAttackDamage(eagle,enermyPlates) == AttackType.NormalAttack)//일반공격과 특수공격 중 피해를 많이 줄 공격에 5%상승
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, true,"독수리 일반공격이 더 큰 피해를 입힘");
-                }
-                else
-                {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, false, "독수리 일반공격이 더 큰 피해를 입힘");
-                }
-            }
-        }
-
-        //소환수, 소환수의 플레이트 번호, 소환수의 특수공격첫번째, 특수공격배열 인덱스번호, 타겟플레이트, 타겟플레이트 변호, 확률
-        AttackPrediction attackPrediction = new AttackPrediction(eagle, eaglePlateIndex, eagle.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
-        return attackPrediction;
-    }
-
-
-    // 확률 값을 설정하고 조정하여 반환하는 메소드
-    public AttackProbability AdjustAttackProbabilities(AttackProbability currentProbabilities, float AttackChange, bool isNormalAttack, string reason)
-    {
-        if (isNormalAttack)
-        {
-            // 일반 공격 확률을 증가시키고, 특수 공격 확률을 그만큼 감소
-            currentProbabilities.normalAttackProbability += AttackChange;
-            currentProbabilities.specialAttackProbability -= AttackChange;
-            Debug.Log($"일반 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
-        }
-        else
-        {
-            // 특수 공격 확률을 증가시키고, 일반 공격 확률을 그만큼 감소
-            currentProbabilities.specialAttackProbability += AttackChange;
-            currentProbabilities.normalAttackProbability -= AttackChange;
-            Debug.Log($"특수 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
-        }
-        return currentProbabilities;
-    }
 
     private string GetPredictionDetails(AttackPrediction prediction)
     {

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/SnakeAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/SnakeAttackPrediction.cs
@@ -2,15 +2,66 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class SnakeAttackPrediction : MonoBehaviour
+public class SnakeAttackPrediction : MonoBehaviour, IAttackPrediction
 {
-    private PlateController plateController;
 
-    private void Awake()
+    public SummonType getPreSummonType()
     {
-        plateController = GetComponent<PlateController>();
+        return SummonType.Snake;
     }
 
+    //뱀 예측공격
+    public AttackPrediction getAttackPrediction(Summon snake, int snakePlateIndex, List<Plate> playerPlates, List<Plate> enermyPlates)
+    {
+        // 기본값 설정: 일반 공격 50%, 특수 공격 50%
+        AttackProbability attackProbability = new AttackProbability(50f, 50f);
+        int attackIndex = getClosestEnermyIndex(enermyPlates);
+        AttackPrediction attackPrediction = new AttackPrediction(snake, snakePlateIndex, snake.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
+
+        if (IsEnermyAlreadyPoisoned(enermyPlates))
+        { //몬스터들이 이미 중독 상태인가?
+            attackProbability = new AttackProbability(100f, 0f);
+            attackPrediction = new AttackPrediction(snake, snakePlateIndex, snake.getAttackStrategy(), 0, enermyPlates, attackIndex, attackProbability); //일반공격으로
+        }
+        else if (!canUseSpecialAttack(snake)) //특수공격을 사용할 수 있는가?
+        {
+            attackProbability = new AttackProbability(100f, 0f);
+            attackPrediction = new AttackPrediction(snake, snakePlateIndex, snake.getAttackStrategy(), 0, enermyPlates, attackIndex, attackProbability); //일반공격으로
+        }
+        else
+        {
+            if (isEnermyCountOverTwo(enermyPlates)) //적이 2마리 이상인가?
+            {
+                if (AllEnermyHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "뱀 적의 체력이 모두 50%이상");
+                }
+                else
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "뱀 적의 체력이 모두 50%가 아님");
+                }
+                if (hasMonsterWithMoreThan4Attacks(enermyPlates)) //몬스터 중 공격의 개수가 4개 이상인 몹이 존재하는가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "뱀 적의 몬스터중 공격이 4개 이상인 몹이 있는가");
+                }
+            }
+            else //1마리 일때
+            {
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "뱀 적이 1마리 뿐");
+                if (AllEnermyHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "뱀 적의 체력이 모두 50% 이상");
+                }
+                if (getIndexOfNormalAttackCanKill(snake, enermyPlates) != -1) //일반 공격 시 몬스터를 물리칠 수 있는가?
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "뱀 일반 공격시 처치가능");
+                }
+            }
+            attackPrediction = new AttackPrediction(snake, snakePlateIndex, snake.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
+        }
+
+        return attackPrediction;
+    }
 
 
 
@@ -73,22 +124,6 @@ public class SnakeAttackPrediction : MonoBehaviour
     }
 
 
-    // 가장 가까운 적을 공격했을 때 물리칠 수 있는지 확인하는 메소드
-    public bool CanNormalAttackKill(Summon snake, List<Plate> enermyPlates)
-    {
-        int closestIndex = getClosestEnermyIndex(enermyPlates);
-        if (closestIndex != -1)
-        {
-            Summon closestEnermySummon = enermyPlates[closestIndex].getCurrentSummon();
-            if (closestEnermySummon != null && snake.getAttackPower() >= closestEnermySummon.getNowHP())
-            {
-                return true; // 가장 가까운 적을 일반 공격으로 처치할 수 있으면 true 반환
-            }
-        }
-        return false; // 처치할 수 없으면 false 반환
-    }
-
-
     // 적이 2마리 이상 있는지 확인하는 메소드
     public bool isEnermyCountOverTwo(List<Plate> enermyPlates)
     {
@@ -118,6 +153,24 @@ public class SnakeAttackPrediction : MonoBehaviour
     }
 
 
+    // 가장 가까운 적을 공격했을 때 물리칠 수 있는지 확인하는 메소드
+    public int getIndexOfNormalAttackCanKill(Summon snake, List<Plate> enermyPlates)
+    {
+        // 가장 가까운 적의 인덱스를 가져옴
+        int closestIndex = getClosestEnermyIndex(enermyPlates);
+
+        if (closestIndex != -1)
+        {
+            Summon closestEnermySummon = enermyPlates[closestIndex].getCurrentSummon();
+            // 가장 가까운 적의 소환수가 있고, 일반 공격으로 물리칠 수 있는지 확인
+            if (closestEnermySummon != null && snake.getAttackPower() >= closestEnermySummon.getNowHP())
+            {
+                return closestIndex; // 공격으로 물리칠 수 있으면 인덱스 반환
+            }
+        }
+
+        return -1; // 공격 가능한 적이 없으면 -1 반환
+    }
 
 
     public int getClosestEnermyIndex(List<Plate> enermyPlates)
@@ -131,5 +184,25 @@ public class SnakeAttackPrediction : MonoBehaviour
             }
         }
         return -1; // 적 소환수가 없으면 -1 반환
+    }
+
+    // 확률 값을 설정하고 조정하여 반환하는 메소드
+    private AttackProbability AdjustAttackProbabilities(AttackProbability currentProbabilities, float AttackChange, bool isNormalAttack, string reason)
+    {
+        if (isNormalAttack)
+        {
+            // 일반 공격 확률을 증가시키고, 특수 공격 확률을 그만큼 감소
+            currentProbabilities.normalAttackProbability += AttackChange;
+            currentProbabilities.specialAttackProbability -= AttackChange;
+            Debug.Log($"일반 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+        }
+        else
+        {
+            // 특수 공격 확률을 증가시키고, 일반 공격 확률을 그만큼 감소
+            currentProbabilities.specialAttackProbability += AttackChange;
+            currentProbabilities.normalAttackProbability -= AttackChange;
+            Debug.Log($"특수 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+        }
+        return currentProbabilities;
     }
 }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/StatePanel.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/StatePanel.cs
@@ -1,9 +1,22 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class StatePanel: MonoBehaviour
+public interface stateObserver
+{
+    void StateUpdate();
+}
+
+public interface UpdateStateObserver
+{
+    void AddObserver(stateObserver observer);
+    void RemoveObserver(stateObserver observer);
+    void NotifyObservers();
+}
+
+public class StatePanel: MonoBehaviour, stateObserver
 {
     [SerializeField] private Summon stateSummon; //Summon
     [SerializeField] private Image summonImage; //image
@@ -18,6 +31,7 @@ public class StatePanel: MonoBehaviour
     public void setStatePanel(Summon stateSummon, bool isEnemyPlate)
     {
         this.stateSummon = stateSummon;
+        stateSummon.AddObserver(this); // 옵저버로 등록
 
         // 소환수의 이미지를 패널에 설정
         if (summonImage != null && stateSummon != null && stateSummon.getImage() != null)
@@ -46,6 +60,8 @@ public class StatePanel: MonoBehaviour
             NormalAttackButton.image.sprite = stateSummon.normalAttackSprite;   // 일반 공격 스프라이트 설정
             SpecialAttackButton.image.sprite = stateSummon.specialAttackSprite; // 특수 공격 스프라이트 설정
         }
+
+        StateUpdate();
     }
 
 
@@ -54,4 +70,21 @@ public class StatePanel: MonoBehaviour
         return stateSummon;
     }
 
+    public void StateUpdate()
+    {
+        if (stateSummon != null)
+        {
+            // 소환수가 사망 상태인지 체크
+            if (stateSummon.getNowHP() <= 0)
+            {
+                // 사망 시 StatePanel 비활성화
+                gameObject.SetActive(false);
+                return;
+            }
+
+            // HP 슬라이더 업데이트
+            float sliderHP = (float)(stateSummon.getNowHP() / stateSummon.getMaxHP());
+            HPSlider.value = sliderHP;
+        }
+    }
 }

--- a/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
@@ -6,23 +6,22 @@ public class Cat : Summon
 {
     private void Awake()
     {
-        summonInitialize();
+        summonInitialize(5);
     }
 
-    public override void summonInitialize()
+    public void summonInitialize(int n)
     {
         summonName = "Cat";
-        maxHP = 100;
+        maxHP = 100 * n;
         nowHP = maxHP;
-        attackPower = 15; //일반공격
+        attackPower = 15 * n; //일반공격
         summonRank = SummonRank.Low; // 하급 소환수
         summonType = SummonType.Cat;
-        heavyAttakPower = 20;
+        heavyAttakPower = 20 * n;
         // 일반 공격: 가장 가까운 적 공격
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower ,1);
         // 특수 공격: 전체 적 공격
         specialAttackStrategies = new IAttackStrategy[] { new ClosestEnemyAttackStrategy(StatusType.None, heavyAttakPower, 1) }; //근접공격, 20데미지, 쿨타임1턴
-        //specialAttackStrategies = new IAttackStrategy[] { new TargetedAttackStrategy(StatusType.LifeDrain, 0.1, 4,2) }; //근접공격, 20데미지, 쿨타임1턴
     }
 
     //일반 공격과 특수공격이 같은 방식의 경우 데미지가 attackPower로 들어가는 로직이기 때문에 잠깐 SpecialPower로 하고 되돌리게

--- a/Workpiece/Summoner/Assets/Script/Summons/Eagle.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Eagle.cs
@@ -6,18 +6,18 @@ public class Eagle : Summon
 {
     private void Awake()
     {
-        summonInitialize();
+        summonInitialize(5);
     }
 
-    public override void summonInitialize()
+    public void summonInitialize(int n)
     {
         summonName = "Eagle";
-        maxHP = 400;
+        maxHP = 400 * n;
         nowHP = maxHP;
-        attackPower = 45; //일반공격
+        attackPower = 45 * n; //일반공격
         summonRank = SummonRank.High; // 상급 소환수
         summonType = SummonType.Eagle;
-        heavyAttakPower = 30;
+        heavyAttakPower = 30 * n;
         // 일반 공격: 가장 가까운 적 공격
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 1);
         // 특수 공격: 타겟 지정 공격

--- a/Workpiece/Summoner/Assets/Script/Summons/Fox.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Fox.cs
@@ -8,21 +8,21 @@ public class Fox : Summon
 
     private void Awake()
     {
-        summonInitialize();
+        summonInitialize(5);
 
     }
 
-    public override void summonInitialize()
+    public void summonInitialize(int n)
     {
         summonName = "Fox"; //이름 Fox
-        maxHP = 200; //최대체력 200
+        maxHP = 200 * n; //최대체력 200
         nowHP = maxHP; //현재체력 // 깨어날땐 최대체력으로 설정
-        attackPower = 15; //일반공격
+        attackPower = 15 * n; //일반공격
         summonRank = SummonRank.Low; // 하급 소환수
         summonType = SummonType.Fox;
         // 일반 공격: 가장 가까운 적 공격
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 0);
-        specialAttackStrategies = new IAttackStrategy[] { new TargetedAttackStrategy(StatusType.Upgrade, 0.2, 3, 1) };//공격력 강화, 20% 상승, 쿨타임 2턴
+        specialAttackStrategies = new IAttackStrategy[] { new TargetedAttackStrategy(StatusType.Upgrade, 0.2, 3, 1) };//공격력 강화, 20% 상승, 쿨타임 3턴 //지속시간 1턴
     }
 
 

--- a/Workpiece/Summoner/Assets/Script/Summons/Rabbit.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Rabbit.cs
@@ -7,15 +7,15 @@ public class Rabbit : Summon
 {
     private void Awake()
     {
-        summonInitialize();
+        summonInitialize(5);
     }
 
-    public override void summonInitialize()
+    public void summonInitialize(int n)
     {
         summonName = "Rabbit";
-        maxHP = 250;
+        maxHP = 250 * n;
         nowHP = maxHP;
-        attackPower = 20; //일반공격
+        attackPower = 20*n; //일반공격
         summonRank = SummonRank.Medium; // 중급 소환수
         summonType = SummonType.Rabbit;
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower,1); //근접공격

--- a/Workpiece/Summoner/Assets/Script/Summons/Snake.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Snake.cs
@@ -6,15 +6,15 @@ public class Snake : Summon
 {
     private void Awake()
     {
-        summonInitialize();
+        summonInitialize(5);
     }
 
-    public override void summonInitialize()
+    public void summonInitialize(int n)
     {
         summonName = "Snake";
-        maxHP = 200;
+        maxHP = 200 * n;
         nowHP = maxHP;
-        attackPower = 30; //일반공격
+        attackPower = 30 * n; //일반공격
         summonRank = SummonRank.Medium; // 중급 소환수
         summonType = SummonType.Snake;
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 1); //근접 공격

--- a/Workpiece/Summoner/Assets/Script/Summons/Wolf.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Wolf.cs
@@ -6,19 +6,20 @@ public class Wolf : Summon
 {
     private void Awake()
     {
-        summonInitialize();
+        summonInitialize(5);
     }
 
-    public override void summonInitialize()
+    public void summonInitialize(int n)
     {
         summonName = "Wolf";
-        maxHP = 300;
+        maxHP = 300*n;
         nowHP = maxHP;
-        attackPower = 50; //일반공격
+        attackPower = 50 * n; //일반공격
+        heavyAttakPower = 25 * n;
         summonRank = SummonRank.High; // 중급 소환수
         summonType = SummonType.Wolf;
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 1); //근접공격
-        specialAttackStrategies = new IAttackStrategy[] { new AttackAllEnemiesStrategy(StatusType.None, 25, 2) };//전체공격, 25데미지, 쿨타임2턴
+        specialAttackStrategies = new IAttackStrategy[] { new AttackAllEnemiesStrategy(StatusType.None, heavyAttakPower, 2) };//전체공격, 25데미지, 쿨타임2턴
     }
 
 


### PR DESCRIPTION
- 옵저버 패턴으로 공격받을때, 힐받을때 StatePanel을 업데이트시켜 체력의 변화를 보이게 하였고 체력이 0 아래로 내려가면 상태창을 꺼지게 구현

- 소환수 공격 예측 알고리즘 코드 수정 및 오브젝트 씬마다 배치

- 상태이상 및 쿨타임 로직 수정 데미지는 돌아오는 자신의 턴에 적용되게 하였고 스턴은 상대방 턴 끝날때, 혼란,강화는 적용한 턴 끝날때 쿨타임이 줄어들게 수정

추후 수정내용
재소환한 소환수는 공격을 해선 안됨.
- 재소환된 소환수에 대해서 공격여부를 false로 하여 턴 끝날때 풀리게 할 예정