### PR TITLE
상태창 재소환시 해당 소환수로 변경

### DIFF
--- a/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_4Stage.unity
+++ b/Workpiece/Summoner/Assets/Screen/FightScene/Fight Screen_4Stage.unity
@@ -1755,6 +1755,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 49071052}
+  - {fileID: 2142093828}
   m_Father: {fileID: 342250389}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
@@ -1940,17 +1941,6 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 1693056096}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &186434604 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5491859847190021652, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-  m_PrefabInstance: {fileID: 1856290374}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 636105828}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -3002,6 +2992,7 @@ MonoBehaviour:
   - {fileID: 1152497999}
   - {fileID: 21840651}
   plateController: {fileID: 893681172}
+  statePanel: {fileID: 1291976794}
 --- !u!114 &299313757 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7001086004006574865, guid: 425618ad78d48fc47930e89c04062585, type: 3}
@@ -3405,7 +3396,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 49071052}
   m_HandleRect: {fileID: 0}
@@ -4123,6 +4114,10 @@ PrefabInstance:
       propertyPath: battleController
       value: 
       objectReference: {fileID: 893681171}
+    - target: {fileID: 6417078377840297505, guid: 425618ad78d48fc47930e89c04062585, type: 3}
+      propertyPath: statePanelScript
+      value: 
+      objectReference: {fileID: 1291976794}
     - target: {fileID: 6417078377840297505, guid: 425618ad78d48fc47930e89c04062585, type: 3}
       propertyPath: summonController
       value: 
@@ -7267,24 +7262,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 636078997}
   m_CullTransparentMesh: 1
---- !u!1 &636105828 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2532585274545343172, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-  m_PrefabInstance: {fileID: 1856290374}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &636105831
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 636105828}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f6eef2be85f6754ca145d6870f804af, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  summon: {fileID: 6006135561973635161, guid: 8fd297f85265bc04894ce80f6e81ac6c, type: 3}
 --- !u!1 &657750064
 GameObject:
   m_ObjectHideFlags: 0
@@ -8390,6 +8367,10 @@ PrefabInstance:
       propertyPath: battleController
       value: 
       objectReference: {fileID: 893681171}
+    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: statePanelScript
+      value: 
+      objectReference: {fileID: 1291976794}
     - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
       propertyPath: summonController
       value: 
@@ -10407,7 +10388,7 @@ MonoBehaviour:
   - {fileID: 1693056098}
   enermyPlates:
   - {fileID: 9184813848463463012}
-  - {fileID: 1856290379}
+  - {fileID: 958411495}
   - {fileID: 792077600}
 --- !u!114 &893681173
 MonoBehaviour:
@@ -10491,6 +10472,179 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f43ba149b0784942a9fa334d497d6fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &958411490
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1545898996}
+    m_Modifications:
+    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: summonImg
+      value: 
+      objectReference: {fileID: 958411493}
+    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: statePanel
+      value: 
+      objectReference: {fileID: 1291976790}
+    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: currentSummon
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: battleController
+      value: 
+      objectReference: {fileID: 893681171}
+    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: statePanelScript
+      value: 
+      objectReference: {fileID: 1291976794}
+    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: summonController
+      value: 
+      objectReference: {fileID: 290545741}
+    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: onMousePlateScript
+      value: 
+      objectReference: {fileID: 1291976794}
+    - target: {fileID: 6901903308100531676, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_Name
+      value: SecondPlate
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2532585274545343172, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 958411494}
+  m_SourcePrefab: {fileID: 100100000, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+--- !u!224 &958411491 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+  m_PrefabInstance: {fileID: 958411490}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &958411492 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2532585274545343172, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+  m_PrefabInstance: {fileID: 958411490}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &958411493 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5491859847190021652, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+  m_PrefabInstance: {fileID: 958411490}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 958411492}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &958411494
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 958411492}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f6eef2be85f6754ca145d6870f804af, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  summon: {fileID: 6006135561973635161, guid: 8fd297f85265bc04894ce80f6e81ac6c, type: 3}
+--- !u!114 &958411495 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+  m_PrefabInstance: {fileID: 958411490}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bdb93be9a7fc3e745a5d736690bdc844, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &959924360
@@ -13740,6 +13894,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 893681171}
     - target: {fileID: 6417078377840297505, guid: 425618ad78d48fc47930e89c04062585, type: 3}
+      propertyPath: statePanelScript
+      value: 
+      objectReference: {fileID: 1291976794}
+    - target: {fileID: 6417078377840297505, guid: 425618ad78d48fc47930e89c04062585, type: 3}
       propertyPath: summonController
       value: 
       objectReference: {fileID: 290545741}
@@ -14265,7 +14423,7 @@ MonoBehaviour:
   stateSummon: {fileID: 0}
   summonImage: {fileID: 959924362}
   HPSlider: {fileID: 342250390}
-  shieldImage: {fileID: 0}
+  shieldImage: {fileID: 2142093829}
   NormalAttackButton: {fileID: 1052664224}
   SpecialAttackButton: {fileID: 541171654}
 --- !u!1 &1295376699
@@ -15854,6 +16012,8 @@ GameObject:
   - component: {fileID: 1469478337}
   - component: {fileID: 1469478338}
   - component: {fileID: 1469478339}
+  - component: {fileID: 1469478340}
+  - component: {fileID: 1469478341}
   m_Layer: 5
   m_Name: Player
   m_TagString: Untagged
@@ -15910,7 +16070,8 @@ MonoBehaviour:
   haveTexture: {fileID: 2800000, guid: 7d626db1d5084a746a419e605d76699e, type: 3}
   summonButton: {fileID: 839549381}
   reSummonButton: {fileID: 1625915091}
-  summonFailSound: {fileID: 0}
+  clickSound: {fileID: 1469478340}
+  failSound: {fileID: 1469478340}
   summonController: {fileID: 290545741}
   turnController: {fileID: 893681170}
   battleController: {fileID: 893681171}
@@ -15931,6 +16092,198 @@ MonoBehaviour:
   ClearResult: {fileID: 1238532517}
   alertFail: {fileID: 303552710}
   FailResult: {fileID: 303552715}
+--- !u!82 &1469478340
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1469478336}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: -7486461387043459178, guid: 44714e3b084d4f64b8ccb5af3496bee0, type: 2}
+  m_audioClip: {fileID: 8300000, guid: 6c414ab7c61564346bb59d72ad2e754a, type: 3}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!82 &1469478341
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1469478336}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: -7486461387043459178, guid: 44714e3b084d4f64b8ccb5af3496bee0, type: 2}
+  m_audioClip: {fileID: 8300000, guid: 0babceada10597b428cff2b3f642d1ab, type: 3}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &1475674743
 GameObject:
   m_ObjectHideFlags: 0
@@ -16428,7 +16781,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9184813848463463008}
-  - {fileID: 1856290375}
+  - {fileID: 958411491}
   - {fileID: 792077596}
   m_Father: {fileID: 313031150}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -17470,6 +17823,10 @@ PrefabInstance:
       propertyPath: battleController
       value: 
       objectReference: {fileID: 893681171}
+    - target: {fileID: 6417078377840297505, guid: 425618ad78d48fc47930e89c04062585, type: 3}
+      propertyPath: statePanelScript
+      value: 
+      objectReference: {fileID: 1291976794}
     - target: {fileID: 6417078377840297505, guid: 425618ad78d48fc47930e89c04062585, type: 3}
       propertyPath: summonController
       value: 
@@ -19090,142 +19447,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1847576045}
   m_CullTransparentMesh: 1
---- !u!1001 &1856290374
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1545898996}
-    m_Modifications:
-    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: summonImg
-      value: 
-      objectReference: {fileID: 186434604}
-    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: statePanel
-      value: 
-      objectReference: {fileID: 1291976790}
-    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: battleController
-      value: 
-      objectReference: {fileID: 893681171}
-    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: summonController
-      value: 
-      objectReference: {fileID: 290545741}
-    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: onMousePlateScript
-      value: 
-      objectReference: {fileID: 1291976794}
-    - target: {fileID: 6901903308100531676, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_Name
-      value: SecondPlate
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2532585274545343172, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 636105831}
-  m_SourcePrefab: {fileID: 100100000, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
---- !u!224 &1856290375 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7980598692303977879, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-  m_PrefabInstance: {fileID: 1856290374}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1856290379 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
-  m_PrefabInstance: {fileID: 1856290374}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bdb93be9a7fc3e745a5d736690bdc844, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1860447144 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2532585274545343172, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
@@ -21455,6 +21676,81 @@ RectTransform:
   m_AnchoredPosition: {x: 257.5, y: 110}
   m_SizeDelta: {x: -625, y: 130}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2142093827
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2142093828}
+  - component: {fileID: 2142093830}
+  - component: {fileID: 2142093829}
+  m_Layer: 5
+  m_Name: Shield
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2142093828
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2142093827}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 173231527}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 1}
+  m_SizeDelta: {x: -40, y: -18}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2142093829
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2142093827}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 756322565, guid: c2eca6ae155aef2469e006168882aed9, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 0
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2142093830
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2142093827}
+  m_CullTransparentMesh: 1
 --- !u!1 &2146696015
 GameObject:
   m_ObjectHideFlags: 0
@@ -21800,6 +22096,10 @@ PrefabInstance:
       propertyPath: battleController
       value: 
       objectReference: {fileID: 893681171}
+    - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
+      propertyPath: statePanelScript
+      value: 
+      objectReference: {fileID: 1291976794}
     - target: {fileID: 6417078377840297505, guid: 5235d1e84b862924486d612bdee2af51, type: 3}
       propertyPath: summonController
       value: 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/AttackAllEnemiesStrategy.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/AttackAllEnemiesStrategy.cs
@@ -49,7 +49,7 @@ public class AttackAllEnemiesStrategy : IAttackStrategy
                         double upgradeAttackPower = attacker.getSpecialAttackStrategy()[SpecialAttackArrayIndex].getSpecialDamage();
                         StatusEffect upgradeEffect = new StatusEffect(StatusType.Upgrade, statusTime, upgradeAttackPower);
                         target.ApplyStatusEffect(upgradeEffect);
-                        Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}에게 공격력 {target.getAttackPower()*upgradeAttackPower} 만큼 상승 시켰습니다.");
+                        Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}에게 공격력 {(int)(target.getAttackPower()*upgradeAttackPower)} 만큼 상승 시켰습니다.");
                         break;
                     case StatusType.Heal:
                         double healAmount = target.getMaxHP() * attacker.getSpecialAttackStrategy()[SpecialAttackArrayIndex].getSpecialDamage(); // 최대 체력의 20%만큼 회복

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/StatusEffect.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/StatusEffect.cs
@@ -27,6 +27,7 @@ public class StatusEffect
 
     private bool applyOnce = false;
 
+    private double originAttack;
     public StatusEffect(StatusType type, int eTime, double damage=0, Summon attacker = null)
     {
         statusType = type;
@@ -84,6 +85,15 @@ public class StatusEffect
                 Debug.Log("정의되지 않은 상태이상입니다.");
                 break;
         }
+    }
+
+    public double getOriginAttack()
+    {
+        return originAttack;
+    }
+    public void setOriginAttack(double originAttack)
+    {
+        this.originAttack = originAttack;
     }
 
     public bool shouldApplyOnce()

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/TargetedAttackStrategy.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/TargetedAttackStrategy.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -27,7 +28,8 @@ public class TargetedAttackStrategy : IAttackStrategy
             switch (statusType)
             {
                 case StatusType.Heal:
-                    double healAmount = target.getMaxHP() * 0.3; // 최대 체력의 30%만큼 회복
+                    double healAmount = (int)target.getMaxHP() * 0.3; // 최대 체력의 30%만큼 회복
+                    healAmount = Math.Floor(healAmount); // 소수점 아래를 버림
                     target.Heal(healAmount);
                     Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}을(를) {healAmount}만큼 치유했습니다.");
                     break;
@@ -51,7 +53,7 @@ public class TargetedAttackStrategy : IAttackStrategy
                     double upgradeAttackPower = attacker.getSpecialAttackStrategy()[Arrayindex].getSpecialDamage();
                     StatusEffect upgradeEffect = new StatusEffect(StatusType.Upgrade, statusTime, upgradeAttackPower);
                     target.ApplyStatusEffect(upgradeEffect);
-                    Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}에게 공격력 {upgradeAttackPower*100} 만큼 상승 시켰습니다.");
+                    Debug.Log($"{attacker.getSummonName()}이(가) {target.getSummonName()}에게 공격력 {(int)(target.getAttackPower() * upgradeAttackPower)} 만큼 상승 시켰습니다.");
                     break;
                 case StatusType.OnceInvincibility: //무적
                     target = attacker; //자기자신이 대상

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/EnermyAttackController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/EnermyAttackController.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Net.NetworkInformation;
 using UnityEngine;
 
 
@@ -26,7 +25,7 @@ public class EnermyAttackController : MonoBehaviour
         {
             Summon attackingSummon = enermyPlate[enermyPlateIndex].getCurrentSummon(); //플레이트에 소환수를 차례로 가져와서
             // 소환수가 스턴 상태인지 확인
-            if (IsSummonStunned(attackingSummon))
+            if (attackingSummon.IsStun())
             {
                 continue; // 스턴 상태면 다음 소환수로 넘어감
             }
@@ -71,12 +70,7 @@ public class EnermyAttackController : MonoBehaviour
         return false; // 변경된 리스트 반환
     }
 
-   
-    private bool IsSummonStunned(Summon summon)
-    {
-        List<StatusType> statusList = summon.getAllStatusTypes();
-        return statusList.Contains(StatusType.Stun);
-    }
+    //힐 사용이 가능하다면 힐 사용
     private void useHealIfAvailable(Summon attackingSummon, List<Plate> enermyPlate, int enermyPlateIndex)
     {
         IAttackStrategy[] specialAttackStrategies = attackingSummon.getSpecialAttackStrategy(); // 사용가능한 스킬들을 가져옴
@@ -91,36 +85,6 @@ public class EnermyAttackController : MonoBehaviour
             }
         }
     }
-
-    //private void EnerymyAttackLogic(Summon attackingSummon, Summon target, int targetIndex)
-    //{
-    //    if (!attackingSummon.IsCooltime()) //쿨타임중인 스킬이 없을경우
-    //    {
-    //        AttackType selectedAttakType = SelectAttackType(); //일반공격과 특수공격을 랜덤으로 받아옴
-    //        if (selectedAttakType == AttackType.SpecialAttack)
-    //        {
-    //            //쿨타임이 없는 특수스킬을 사용하게 한다.
-    //            List<int> availableSpecialAttacks = attackingSummon.getAvailableSpecialAttack();  // 쿨타임이 없는 특수 스킬 목록을 가져옴
-
-
-    //            int selectSpecialAttackIndex = getRandomAvilableSpecialAttackIndex(availableSpecialAttacks); //랜덤의 특수스킬 번호를 가져옴
-    //            int selectedPlateIndex = plateController.getClosestPlayerPlatesIndex(attackingSummon); //임시로 가장 가까운적 공격하게 함. 나중에 수정필요
-    //            algorithm.ExecuteEnermyAlgorithm(attackingSummon, targetIndex); //알고리즘 실행
-
-    //            battleController.SpecialAttackLogic(attackingSummon, selectedPlateIndex, selectSpecialAttackIndex); //특수스킬 사용
-    //        }
-    //        else
-    //        {
-    //            enermyNormalAttackLogic(attackingSummon); //평타
-    //        }
-    //    }
-    //    else //스킬들이 쿨타임이여서 평타만 공격
-    //    {
-    //        enermyNormalAttackLogic(attackingSummon);
-    //    }
-    //}   
-
-
 
 
     //등급별 연속공격 가능여부

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/SummonController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/SummonController.cs
@@ -30,6 +30,7 @@ public class SummonController : MonoBehaviour
     [Header("소환수 프리팹 목록")]
     private Summon selectedSummon; // 선택된 소환수
 
+
     private void Awake()
     {
         // 싱글톤 패턴 구현
@@ -79,6 +80,7 @@ public class SummonController : MonoBehaviour
         isSummoning = false;
         darkBackground.SetActive(false);
         plateController.ResetPlayerPlateHighlight();
+       
     }
 
     // 재소환 코루틴 (재소환 로직)
@@ -104,6 +106,7 @@ public class SummonController : MonoBehaviour
         darkBackground.SetActive(false);
 
         plateController.ResetPlayerPlateHighlight();
+
     }
 
     //차례로 재소환 로직
@@ -307,4 +310,5 @@ public class SummonController : MonoBehaviour
     {
         player.setSelectedPlateIndex(index);
     }
+
 }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/TurnController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/TurnController.cs
@@ -27,14 +27,21 @@ public class TurnController : MonoBehaviour
     {
         if (currentTurn == Turn.PlayerTurn)  // 플레이어 턴일 경우
         {
-            //플레이어 턴 시작시 적 플레이트의 상태이상 데미지 적용
-            foreach (var summon in enermy.getEnermyAttackController().getPlateController().getEnermySummons())
+            // 적 소환수 상태 업데이트 및 데미지 처리
+            var enermyPlates = enermy.getEnermyAttackController().getPlateController().getEnermySummons();
+
+            // 상태 업데이트를 먼저 진행
+            foreach (var summon in enermyPlates)
             {
                 summon.UpdateDamageStatusEffects(); // 데미지를 주는 상태이상 업데이트
-                summon.UpdateStunAndCurseStatus(); // 스턴 및 저주 상태 업데이트
+                summon.UpdateStunAndCurseStatus();  // 스턴 및 저주 상태 업데이트
                 summon.getAttackStrategy().ReduceCooldown(); // 일반 공격 쿨타임 감소
             }
-            foreach(var summon in player.getPlateController().getPlayerSummons())
+
+            player.getPlateController().CompactEnermyPlates(); //앞당기기
+
+
+            foreach (var summon in player.getPlateController().getPlayerSummons())
             {
                 summon.UpdateSpecialAttackCooldowns(); // 특수 공격 쿨타임 업데이트
             }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAlgorithm.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAlgorithm.cs
@@ -329,9 +329,10 @@ public class EnermyAlgorithm : MonoBehaviour
             if (randomValue < 30f) //강공격
             {
                 Debug.Log($"{attacker.name} 의 강공격");
+                double originPower = attacker.getAttackPower();
                 attacker.setAttackPower(attacker.getHeavyAttakPower()); //공격력을 강공격력으로 전환
                 attacker.normalAttack(plateController.getPlayerPlates(), plateController.getClosestPlayerPlatesIndex(attacker)); //일반공격수행
-                attacker.setAttackPower(attacker.getAttackPower()); //원래 공격력으로 되돌리기
+                attacker.setAttackPower(originPower); //원래 공격력으로 되돌리기
             }
             else //일반 공격력으로 공격
             {
@@ -419,9 +420,10 @@ public class EnermyAlgorithm : MonoBehaviour
         if (randomValue < 30f) //강공격
         {
             Debug.Log($"{attacker.name} 의 강공격");
+            double originPower = attacker.getAttackPower();
             attacker.setAttackPower(attacker.getHeavyAttakPower()); //공격력을 강공격력으로 전환
             attacker.normalAttack(plateController.getPlayerPlates(), plateController.getClosestPlayerPlatesIndex(attacker)); //일반공격수행
-            attacker.setAttackPower(attacker.getAttackPower()); //원래 공격력으로 되돌리기
+            attacker.setAttackPower(originPower); //원래 공격력으로 되돌리기
         }
         else //일반 공격력으로 공격
         {

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs
@@ -34,13 +34,45 @@ public class CatAttackPrediction : MonoBehaviour, IAttackPrediction
             }
             else
             { //특수공격에 +5%
-                attackProbability = AdjustAttackProbabilities(attackProbability, 5f, false, "고양이 특수공격으로 처치 불가능");
+                if(getMostDamageAttack(cat) == AttackType.NormalAttack)
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, true, "고양이 일반공격이 더 많은 데미지를 입힘");
+                }
+                else
+                {
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 5f, false, "고양이 특수공격이 더 많은 데미지를 입힘");
+                }
                 attackIndex = getClosestEnermyIndex(enermyPlates); //적 플레이트 중에서 가장 가까이 있는 인덱스 받기
             }
         }
 
         attackPrediction = new AttackPrediction(cat, catPlateIndex, cat.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
         return attackPrediction;
+    }
+
+    public AttackType getMostDamageAttack(Summon attackingSummon)
+    {
+
+        // 사용 가능한 특수 공격 목록 가져오기
+        IAttackStrategy[] availableSpecialAttacks = attackingSummon.getAvailableSpecialAttacks();
+
+        // 각 특수 공격 확인
+        foreach (IAttackStrategy specialAttack in availableSpecialAttacks)
+        {
+            //특수공격이 null이면 일반공격 반환
+            if(availableSpecialAttacks == null)
+            {
+                return AttackType.NormalAttack;
+            }
+
+            //일반공격력이 더 쌔면 일반공격 반환 고양이는 단일타깃 공격이기때문에 공격력만 비교
+            if (attackingSummon.getAttackPower() > specialAttack.getSpecialDamage())
+                return AttackType.NormalAttack;
+            else
+                return AttackType.SpecialAttack;
+            }
+
+        return AttackType.NormalAttack;
     }
 
 

--- a/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
@@ -6,7 +6,7 @@ public class Cat : Summon
 {
     private void Awake()
     {
-        summonInitialize(5);
+        summonInitialize(1);
     }
 
     public void summonInitialize(int n)
@@ -50,6 +50,7 @@ public class Cat : Summon
         // 해당 공격에 쿨타임 적용
         specialAttack.ApplyCooldown();
         attackPower = originAttackPower;
+        isAttack = false;
     }
 
 

--- a/Workpiece/Summoner/Assets/getParentSummonImage.cs
+++ b/Workpiece/Summoner/Assets/getParentSummonImage.cs
@@ -10,7 +10,7 @@ public class getParenSummontImage : MonoBehaviour
     [SerializeField] private Summon summon; // 적 소환수 직접 할당
     private Plate plate; // 부모 Plate 컴포넌트를 받기 위한 변수
 
-    void Start()
+    void Awake()
     {
         // 부모 오브젝트에 붙어 있는 Plate 컴포넌트를 가져옴
         plate = GetComponentInParent<Plate>();


### PR DESCRIPTION
1. 재소환시킬 소환수 선택 후 재소환시 상태창에 이전 소환수로 남아있던 버그 수정

2. 고양이의 특수공격과 일반공격중 쌘 공격에 5%추가 로직 추가(기존에 안되어있었음)

### 버그
- 적 몬스터들이 예측공격 리스트를 받아오고 순차적으로 공격해야하는데 스턴 검사에서 공격할 몬스터를 받아오지 못해 null값 에러가 걸림.
- 적 몬스터들이 예측공격 리스트만 받아오고 바로 턴을 종료해버림

원인을 못찾는중 디버깅으로 찾고있음.
