### PR TITLE
소환수 예측 알고리즘 수정

### DIFF
--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAlgorithm.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/EnermyAlgorithm.cs
@@ -332,7 +332,7 @@ public class EnermyAlgorithm : MonoBehaviour
             {
                 Debug.Log($"{attacker.name} 의 강공격");
                 double originPower = attacker.getAttackPower();
-                attacker.setAttackPower(attacker.getHeavyAttakPower()); //공격력을 강공격력으로 전환
+                attacker.setAttackPower(attacker.getHeavyAttackPower()); //공격력을 강공격력으로 전환
                 attacker.normalAttack(plateController.getPlayerPlates(), plateController.getClosestPlayerPlatesIndex(attacker)); //일반공격수행
                 attacker.setAttackPower(originPower); //원래 공격력으로 되돌리기
             }
@@ -423,7 +423,7 @@ public class EnermyAlgorithm : MonoBehaviour
         {
             Debug.Log($"{attacker.name} 의 강공격");
             double originPower = attacker.getAttackPower();
-            attacker.setAttackPower(attacker.getHeavyAttakPower()); //공격력을 강공격력으로 전환
+            attacker.setAttackPower(attacker.getHeavyAttackPower()); //공격력을 강공격력으로 전환
             attacker.normalAttack(plateController.getPlayerPlates(), plateController.getClosestPlayerPlatesIndex(attacker)); //일반공격수행
             attacker.setAttackPower(originPower); //원래 공격력으로 되돌리기
         }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs
@@ -21,7 +21,7 @@ public class CatAttackPrediction : MonoBehaviour, IAttackPrediction
         // 일반 공격으로 처치가 가능하면 일반 공격 확률 10% 증가
         if (getIndexOfNormalAttackCanKill(cat, enermyPlates) != -1)
         {
-            attackProbability = AdjustAttackProbabilities(attackProbability, 0.1f, true, "고양이 일반공격으로 처치 가능");
+            attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "고양이 일반공격으로 처치 가능");
             attackIndex = getIndexOfNormalAttackCanKill(cat, enermyPlates); //일반 공격으로 처치가능한 인덱스 받기
         }
         else
@@ -101,7 +101,7 @@ public class CatAttackPrediction : MonoBehaviour, IAttackPrediction
         for (int i = 0; i < enermyPlates.Count; i++)
         {
             Summon enermySummon = enermyPlates[i].getCurrentSummon();
-            if (enermySummon != null && cat.getAttackPower() >= enermySummon.getNowHP())
+            if (enermySummon != null && cat.getHeavyAttackPower() >= enermySummon.getNowHP())
             {
                 // 일반 공격으로 적의 체력을 0 이하로 만들 수 있으면 해당 인덱스 반환
                 return i;
@@ -132,14 +132,14 @@ public class CatAttackPrediction : MonoBehaviour, IAttackPrediction
             // 일반 공격 확률을 증가시키고, 특수 공격 확률을 그만큼 감소
             currentProbabilities.normalAttackProbability += AttackChange;
             currentProbabilities.specialAttackProbability -= AttackChange;
-            Debug.Log($"일반 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+            Debug.Log($"일반 공격 확률이 {AttackChange*100}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
         }
         else
         {
             // 특수 공격 확률을 증가시키고, 일반 공격 확률을 그만큼 감소
             currentProbabilities.specialAttackProbability += AttackChange;
             currentProbabilities.normalAttackProbability -= AttackChange;
-            Debug.Log($"특수 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+            Debug.Log($"특수 공격 확률이 {AttackChange * 100}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
         }
         return currentProbabilities;
     }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/EagleAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/EagleAttackPrediction.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -18,29 +19,29 @@ public class EagleAttackPrediction : MonoBehaviour, IAttackPrediction
         AttackProbability attackProbability = new AttackProbability(50f, 50f);
         int attackIndex = getClosestEnermyIndex(enermyPlates); //가장 가까운적의 인덱스 기본값
 
+        //소환수, 소환수의 플레이트 번호, 소환수의 특수공격첫번째, 특수공격배열 인덱스번호, 타겟플레이트, 타겟플레이트 변호, 확률
+        AttackPrediction attackPrediction = new AttackPrediction(eagle, eaglePlateIndex, eagle.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
 
         if (isTwoOrMoreEnemies(enermyPlates)) //적이 2마리 이상인가?
         {
-            if (isEnermyHealthDifferenceOver30(enermyPlates)) //몬스터 한 쪽이 다른쪽과 비교했을 때 30% 이상 낮은가?
+            if (IsEnermyHealthDifferenceOver30(enermyPlates) != -1) //몬스터 한 쪽이 다른쪽과 비교했을 때 30% 이상 낮은가?
             {
-                if (getIndexOfNormalAttackCanKill(eagle, enermyPlates) != -1) //일반 공격으로 체력이 낮은 쪽을 공격할 수 있는가?
+                int lowestIndex = IsEnermyHealthDifferenceOver30(enermyPlates);
+                if (CanNormalAttack(eagle, enermyPlates, lowestIndex) != -1) //일반 공격으로 체력이 낮은 쪽을 공격할 수 있는가?
                 {
-                    attackIndex = getIndexOfNormalAttackCanKill(eagle, enermyPlates);
+                    attackIndex = CanNormalAttack(eagle, enermyPlates, lowestIndex);
                     attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "독수리 일반공격으로 체력이 낮은 적 공격 가능");
                 }
                 else
                 {
-                    attackIndex = getSpecialAttackKillIndex(eagle, enermyPlates);
+                    attackIndex = lowestIndex;
                     attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "독수리 일반공격으로 체력이 낮은쪽 공격 불가능");
                 }
             }
-            else if (AreEnermyHealthWithin10Percent(enermyPlates)) //몬스터의 체력이 서로 비슷한가?
+            else if (AreEnermyHealthWithin10Percent(eagle,enermyPlates) != -1) //몬스터의 체력이 서로 비슷한가? (10%이내)
             {
-                if (getIndexOfMostHealthEnermy(enermyPlates) != -1) //가장 체력이 많은 몬스터의 인덱스
-                {
-                    attackIndex = getIndexOfMostHealthEnermy(enermyPlates);
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "독수리 몬스터 체력이 10퍼이내로 비슷함");
-                }
+                attackIndex = AreEnermyHealthWithin10Percent(eagle,enermyPlates);
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "독수리 몬스터 체력이 10퍼이내로 비슷함");
             }
         }
         else if (isOnlyOneEnemy(enermyPlates)) //적이 1마리 인가?
@@ -52,6 +53,7 @@ public class EagleAttackPrediction : MonoBehaviour, IAttackPrediction
             }
             else if (getSpecialAttackKillIndex(eagle, enermyPlates) != -1)
             {
+                attackIndex = getSpecialAttackKillIndex(eagle, enermyPlates);
                 attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "독수리 특수공격으로 사냥가능");
             }
             else
@@ -67,8 +69,8 @@ public class EagleAttackPrediction : MonoBehaviour, IAttackPrediction
             }
         }
 
-        //소환수, 소환수의 플레이트 번호, 소환수의 특수공격첫번째, 특수공격배열 인덱스번호, 타겟플레이트, 타겟플레이트 변호, 확률
-        AttackPrediction attackPrediction = new AttackPrediction(eagle, eaglePlateIndex, eagle.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
+        attackPrediction = new AttackPrediction(eagle, eaglePlateIndex, eagle.getSpecialAttackStrategy()[0], 0, enermyPlates, attackIndex, attackProbability);
+        Debug.Log("독수리 겨냥: " + attackIndex);
         return attackPrediction;
     }
 
@@ -96,49 +98,154 @@ public class EagleAttackPrediction : MonoBehaviour, IAttackPrediction
     }
 
 
-    // 몬스터의 한쪽이 다른 쪽의 체력을 비교했을 때 30% 이상 낮은가?
-    public bool isEnermyHealthDifferenceOver30(List<Plate> enermyPlates)
+    // 적의 현재 체력 중 다른 소환수의 체력보다 30% 낮은 소환수 중 가장 체력이 낮은 소환수의 인덱스를 반환하는 메소드
+    public int IsEnermyHealthDifferenceOver30(List<Plate> enermyPlates)
     {
-        if (enermyPlates.Count < 2) return false;
+        if (enermyPlates.Count < 2) return -1;
 
-        double maxHealthRatio = double.MinValue;
-        double minHealthRatio = double.MaxValue;
-        foreach (Plate plate in enermyPlates)
+        int lowestHealthIndex = -1;
+        double lowestHealth = double.MaxValue;
+
+        for (int i = 0; i < enermyPlates.Count; i++)
         {
-            Summon enermySummon = plate.getCurrentSummon();
-            if (enermySummon != null)
+            Summon currentSummon = enermyPlates[i].getCurrentSummon();
+            if (currentSummon == null) continue;
+
+            for (int j = 0; j < enermyPlates.Count; j++)
             {
-                double healthRatio = enermySummon.getNowHP() / enermySummon.getMaxHP();
-                if (healthRatio > maxHealthRatio) maxHealthRatio = healthRatio;
-                if (healthRatio < minHealthRatio) minHealthRatio = healthRatio;
+                if (i == j) continue; // 자기 자신은 비교하지 않음
+
+                Summon compareSummon = enermyPlates[j].getCurrentSummon();
+                if (compareSummon == null) continue;
+
+                // 현재 소환수의 체력 비율 계산 (자기 체력 / 비교 몬스터 체력)
+                double healthRatio = currentSummon.getNowHP() / compareSummon.getNowHP();
+
+                // 조건을 만족하는 경우 중에서 가장 낮은 체력을 가진 소환수의 인덱스를 추적
+                if (healthRatio <= 0.7 && currentSummon.getNowHP() < lowestHealth)
+                {
+                    lowestHealth = currentSummon.getNowHP();
+                    lowestHealthIndex = i;
+                }
             }
         }
 
-        return (maxHealthRatio - minHealthRatio) > 0.3f;
+        return lowestHealthIndex; // 조건을 만족하는 가장 낮은 체력의 소환수 인덱스 반환, 없으면 -1 반환
     }
 
-    // 몬스터들의 체력이 서로 10% 이내 차이인지 검사하는 메소드
-    public bool AreEnermyHealthWithin10Percent(List<Plate> enermyPlates)
+
+    //체력이 가장 낮은 몬스터의 인덱스를 가져와 근접한 인덱스와 비교하는 메소드
+    public bool IsLowestHealthEnermyClosest(Summon attackingSummon, List<Plate> enermyPlates, int lowestIndex)
     {
-        double minHealthRatio = double.MaxValue;
-        double maxHealthRatio = double.MinValue;
+        // 적 소환수가 2개 미만인 경우 비교할 수 없으므로 false 반환
+        if (enermyPlates.Count < 2) return false;
 
-        foreach (Plate plate in enermyPlates)
+        //가장 가까운 인덱스 반환
+        int closetIndex = getClosestEnermyIndex(attackingSummon, enermyPlates);
+
+        if (closetIndex == lowestIndex)
+            return true;
+
+        return false;
+    }
+
+    // 가장 가까운 적 소환수의 인덱스를 반환하는 메소드
+    public int getClosestEnermyIndex(Summon attackingSummon, List<Plate> enermyPlates)
+    {
+        for (int i = 0; i < enermyPlates.Count; i++)
         {
-            Summon enermySummon = plate.getCurrentSummon();
-            if (enermySummon != null)
+            Summon enermySummon = enermyPlates[i].getCurrentSummon();
+            if (enermySummon != null && enermySummon != attackingSummon)
             {
-                // 현재 체력 비율을 계산
-                double healthRatio = enermySummon.getNowHP() / enermySummon.getMaxHP();
-
-                // 최소 및 최대 체력 비율 업데이트
-                if (healthRatio < minHealthRatio) minHealthRatio = healthRatio;
-                if (healthRatio > maxHealthRatio) maxHealthRatio = healthRatio;
+                return i; // 첫 번째로 만나는 유효한 적 소환수의 인덱스를 반환
             }
         }
 
-        // 최대와 최소 체력 비율의 차이가 10% 이내인지 검사
-        return (maxHealthRatio - minHealthRatio) <= 0.1;
+        return -1; // 적 소환수가 없는 경우 -1 반환
+    }
+
+
+    // 몬스터들의 체력이 서로 10% 이내 차이인지 검사하는 메소드
+    public int AreEnermyHealthWithin10Percent(Summon eagle,List<Plate> enermyPlates)
+    {
+        if (enermyPlates.Count < 2) return -1;
+
+        // 사용 가능한 특수 공격이 있는지 먼저 검사
+        bool hasAvailableSpecialAttack = false;
+        for (int i = 0; i < eagle.getSpecialAttackStrategy().Length; i++)
+        {
+            if (!eagle.isSpecialAttackCool(eagle.getSpecialAttackStrategy()[i]))
+            {
+                hasAvailableSpecialAttack = true;
+                break;
+            }
+        }
+
+        // 사용 가능한 특수 공격이 없으면 -1 반환
+        if (!hasAvailableSpecialAttack)
+        {
+            return -1;
+        }
+
+        int maxHealthIndex = -1;
+        double highestHealth = double.MinValue;
+
+        // 최대 현재 체력을 가진 소환수를 찾음
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            Summon currentSummon = enermyPlates[i].getCurrentSummon();
+            if (currentSummon == null) continue;
+
+            double currentHealth = currentSummon.getNowHP();
+
+            if (currentHealth > highestHealth)
+            {
+                highestHealth = currentHealth;
+                maxHealthIndex = i;
+            }
+        }
+
+        // 현재 체력이 가장 높은 소환수가 없다면 -1 반환
+        if (maxHealthIndex == -1) return -1;
+
+        // 반환할 인덱스 초기화 (-1로 설정, 조건 만족 시 maxHealthIndex로 설정)
+        int resultIndex = maxHealthIndex;
+        double maxHealth = highestHealth;
+
+        // 최대 현재 체력을 가진 소환수를 제외하고 나머지 소환수들이 10% 이내 차이인지 검사
+        for (int i = 0; i < enermyPlates.Count; i++)
+        {
+            if (i == maxHealthIndex) continue; // 최대 현재 체력 소환수는 비교에서 제외
+
+            Summon compareSummon = enermyPlates[i].getCurrentSummon();
+            if (compareSummon == null) continue;
+
+            double healthDifference = Math.Abs(maxHealth - compareSummon.getNowHP());
+
+            // 10% 이상의 차이가 나면 조건을 만족하지 않으므로 resultIndex를 -1로 설정하고 종료
+            if (healthDifference > maxHealth * 0.1)
+            {
+                resultIndex = -1;
+                break;
+            }
+        }
+
+        // 모든 소환수가 10% 이내 차이를 만족할 경우에만 최대 체력 소환수의 인덱스를 반환
+        return resultIndex;
+    }
+
+    private int CanNormalAttack(Summon attackingSummon ,List<Plate> enermyPlates , int lowestIndex)
+    {
+        // 적 소환수가 2개 미만인 경우 비교할 수 없으므로 false 반환
+        if (enermyPlates.Count < 2) return -1;
+
+        //가장 가까운 인덱스 반환
+        int closetIndex = getClosestEnermyIndex(attackingSummon, enermyPlates);
+
+        if (closetIndex == lowestIndex)
+            return closetIndex;
+
+        return -1;
     }
 
 
@@ -202,7 +309,25 @@ public class EagleAttackPrediction : MonoBehaviour, IAttackPrediction
     // 특수 공격으로 공격할 수 있는지 확인하고, 공격 가능한 인덱스를 반환하는 메소드
     public int getSpecialAttackKillIndex(Summon eagle, List<Plate> enermyPlates)
     {
-        for(int i=0; i< eagle.getSpecialAttackStrategy().Length; i++)
+        // 사용 가능한 특수 공격이 있는지 먼저 검사
+        bool hasAvailableSpecialAttack = false;
+        for (int i = 0; i < eagle.getSpecialAttackStrategy().Length; i++)
+        {
+            if (!eagle.isSpecialAttackCool(eagle.getSpecialAttackStrategy()[i]))
+            {
+                hasAvailableSpecialAttack = true;
+                break;
+            }
+        }
+
+        // 사용 가능한 특수 공격이 없으면 -1 반환
+        if (!hasAvailableSpecialAttack)
+        {
+            return -1;
+        }
+
+
+        for (int i=0; i< eagle.getSpecialAttackStrategy().Length; i++)
         {
             if (eagle.isSpecialAttackCool(eagle.getSpecialAttackStrategy()[i]))
             {

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/SnakeAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/SnakeAttackPrediction.cs
@@ -50,7 +50,7 @@ public class SnakeAttackPrediction : MonoBehaviour, IAttackPrediction
                 attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "뱀 적이 1마리 뿐");
                 if (AllEnermyHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
                 {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "뱀 적의 체력이 모두 50% 이상");
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "뱀 적의 체력이 50% 이상");
                 }
                 if (getIndexOfNormalAttackCanKill(snake, enermyPlates) != -1) //일반 공격 시 몬스터를 물리칠 수 있는가?
                 {

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/WolfAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/WolfAttackPrediction.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,14 +28,15 @@ public class WolfAttackPrediction : MonoBehaviour, IAttackPrediction
             }
             else if (AllEnermyHealthDown50(enermyPlates)) //몬스터 체력이 모두 50% 이하인가?
             {
-                if (HasSpecificAvailableSpecialAttack(wolf, enermyPlates))
+                if (HasSpecificAvailableSpecialAttack(wolf, wolfPlateIndex, playerPlates))
                 {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "늑대 적 몬스터 체력이 모두 50% 이하");
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "늑대 적 몬스터 체력이 모두 50% 아래고 소환수 중 공격형이 뒤에 존재");
                 }
             }
-            else if (IsEnermyHealthDifferenceOver30(enermyPlates)) //몬스터 한쪽이 다른 쪽에비해 체력이 30% 높은가?
+            else if (IsEnermyHealthDifferenceOver30(enermyPlates) != -1) //몬스터 한쪽이 다른 쪽에비해 체력이 30% 이상 낮은가? 존재하면 가장 낮은 인덱스 반환
             {
-                if (IsLowestHealthEnermyClosest(wolf, enermyPlates)) //낮은쪽의 인덱스가 근접공격하는 인덱스와 동일한가?
+                int lowestIndex = IsEnermyHealthDifferenceOver30(enermyPlates);
+                if (IsLowestHealthEnermyClosest(wolf, enermyPlates, lowestIndex)) //낮은쪽의 인덱스가 근접공격하는 인덱스와 동일한가?
                 {
                     attackProbability = AdjustAttackProbabilities(attackProbability, 20f, true, "늑대 낮은쪽으로 공격하는 인덱스가 동일");
                 }
@@ -75,88 +77,98 @@ public class WolfAttackPrediction : MonoBehaviour, IAttackPrediction
     // 적의 체력이 모두 50% 이상인지 확인하는 메소드
     public bool AllEnermyHealthOver50(List<Plate> enermyPlates)
     {
+        bool hasAliveEnermy = false;
+
         foreach (Plate plate in enermyPlates)
         {
             Summon enermySummon = plate.getCurrentSummon();
-            if (enermySummon != null && enermySummon.getNowHP() / enermySummon.getMaxHP() < 0.5f)
+
+            if (enermySummon != null) // 살아있는 소환수만 검사
             {
-                return false;
+                hasAliveEnermy = true; // 살아있는 소환수가 있음
+                double healthRatio = (double)enermySummon.getNowHP() / enermySummon.getMaxHP();
+
+                if (healthRatio < 0.5) // 체력 비율이 50% 미만인 경우
+                {
+                    return false; // 하나라도 50% 미만인 소환수가 있으면 false 반환
+                }
             }
         }
-        return true;
+
+        return hasAliveEnermy; // 살아있는 소환수가 있고, 모두 50% 이상일 경우 true 반환
     }
 
-    // 적의 체력이 모두 50% 이하인지 확인하는 메소드
+    // 살아있는 적 소환수의 체력이 모두 50% 이하인지 확인하는 메소드
     public bool AllEnermyHealthDown50(List<Plate> enermyPlates)
     {
-        foreach (Plate plate in enermyPlates)
-        {
-            Summon enermySummon = plate.getCurrentSummon();
-            if (enermySummon != null && enermySummon.getNowHP() / enermySummon.getMaxHP() > 0.5f)
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    // 적의 체력 차이가 30% 이상인지 확인하는 메소드
-    public bool IsEnermyHealthDifferenceOver30(List<Plate> enermyPlates)
-    {
-        if (enermyPlates.Count < 2) return false;
-
-        double maxHealthRatio = double.MinValue;
-        double minHealthRatio = double.MaxValue;
+        bool hasAliveEnermy = false;
 
         foreach (Plate plate in enermyPlates)
         {
             Summon enermySummon = plate.getCurrentSummon();
+
             if (enermySummon != null)
             {
-                double healthRatio = enermySummon.getNowHP() / enermySummon.getMaxHP();
-                if (healthRatio > maxHealthRatio) maxHealthRatio = healthRatio;
-                if (healthRatio < minHealthRatio) minHealthRatio = healthRatio;
+                hasAliveEnermy = true; // 살아있는 소환수가 존재함을 확인
+                if (enermySummon.getNowHP() / enermySummon.getMaxHP() > 0.5f)
+                {
+                    return false; // 체력이 50% 초과인 소환수가 있으면 false 반환
+                }
             }
         }
 
-        return (maxHealthRatio - minHealthRatio) > 0.3f;
+        return hasAliveEnermy; // 살아있는 소환수가 모두 50% 이하일 경우 true 반환
     }
 
-    // 적의 체력 차이가 30% 이상인지 확인하고, 체력이 가장 낮은 몬스터의 인덱스를 가져와 근접한 인덱스와 비교하는 메소드
-    public bool IsLowestHealthEnermyClosest(Summon attackingSummon, List<Plate> enermyPlates)
+    // 적의 현재 체력 중 다른 소환수의 체력보다 30% 낮은 소환수 중 가장 체력이 낮은 소환수의 인덱스를 반환하는 메소드
+    public int IsEnermyHealthDifferenceOver30(List<Plate> enermyPlates)
     {
-        // 적 소환수가 2개 미만인 경우 비교할 수 없으므로 false 반환
-        if (enermyPlates.Count < 2) return false;
+        if (enermyPlates.Count < 2) return -1;
 
-        double maxHealthRatio = double.MinValue;
-        double minHealthRatio = double.MaxValue;
         int lowestHealthIndex = -1;
+        double lowestHealth = double.MaxValue;
 
-        // 적 몬스터의 최대 체력 비율과 최소 체력 비율을 계산하고, 최소 체력을 가진 인덱스 저장
         for (int i = 0; i < enermyPlates.Count; i++)
         {
-            Summon enermySummon = enermyPlates[i].getCurrentSummon();
-            if (enermySummon != null)
+            Summon currentSummon = enermyPlates[i].getCurrentSummon();
+            if (currentSummon == null) continue;
+
+            for (int j = 0; j < enermyPlates.Count; j++)
             {
-                double healthRatio = enermySummon.getNowHP() / enermySummon.getMaxHP();
-                if (healthRatio > maxHealthRatio) maxHealthRatio = healthRatio;
-                if (healthRatio < minHealthRatio)
+                if (i == j) continue; // 자기 자신은 비교하지 않음
+
+                Summon compareSummon = enermyPlates[j].getCurrentSummon();
+                if (compareSummon == null) continue;
+
+                // 현재 소환수의 체력 비율 계산 (자기 체력 / 비교 몬스터 체력)
+                double healthRatio = currentSummon.getNowHP() / compareSummon.getNowHP();
+
+                // 조건을 만족하는 경우 중에서 가장 낮은 체력을 가진 소환수의 인덱스를 추적
+                if (healthRatio <= 0.7 && currentSummon.getNowHP() < lowestHealth)
                 {
-                    minHealthRatio = healthRatio;
+                    lowestHealth = currentSummon.getNowHP();
                     lowestHealthIndex = i;
                 }
             }
         }
 
-        // 체력 비율의 차이가 30% 이상인지 확인
-        if ((maxHealthRatio - minHealthRatio) > 0.3f)
-        {
-            // 체력이 가장 낮은 적 소환수의 인덱스와 가장 가까운 적 소환수의 인덱스를 비교
-            int closestIndex = getClosestEnermyIndex(attackingSummon , enermyPlates);
-            return (lowestHealthIndex == closestIndex);
-        }
+        return lowestHealthIndex; // 조건을 만족하는 가장 낮은 체력의 소환수 인덱스 반환, 없으면 -1 반환
+    }
 
-        return false; // 체력 차이가 30% 이상이 아니거나 조건을 만족하지 않으면 false 반환
+
+    //체력이 가장 낮은 몬스터의 인덱스를 가져와 근접한 인덱스와 비교하는 메소드
+    public bool IsLowestHealthEnermyClosest(Summon attackingSummon, List<Plate> enermyPlates, int lowestIndex)
+    {
+        // 적 소환수가 2개 미만인 경우 비교할 수 없으므로 false 반환
+        if (enermyPlates.Count < 2) return false;
+
+        //가장 가까운 인덱스 반환
+        int closetIndex = getClosestEnermyIndex(attackingSummon, enermyPlates);
+
+        if (closetIndex == lowestIndex)
+            return true;
+
+        return false;  
     }
 
     // 가장 가까운 적 소환수의 인덱스를 반환하는 메소드
@@ -179,43 +191,68 @@ public class WolfAttackPrediction : MonoBehaviour, IAttackPrediction
     // 적이 2마리 이상인지 확인하는 메소드
     public bool IsEnermyCountTwoOrMore(List<Plate> enermyPlates)
     {
-        return enermyPlates.Count >= 2;
+        int enermyCount = 0;
+
+        foreach (Plate plate in enermyPlates)
+        {
+            if (plate.getCurrentSummon() != null) // Plate에 소환수가 있는지 확인
+            {
+                enermyCount++;
+                if (enermyCount >= 2) return true; // 2마리 이상이면 true 반환
+            }
+        }
+
+        return false;
     }
 
     // 적이 1마리인지 확인하는 메소드
     public bool IsEnermyCountOne(List<Plate> enermyPlates)
     {
-        return enermyPlates.Count == 1;
+        int enermyCount = 0;
+
+        foreach (Plate plate in enermyPlates)
+        {
+            if (plate.getCurrentSummon() != null) // Plate에 소환수가 있는지 확인
+            {
+                enermyCount++;
+                if (enermyCount > 1) return false; // 2마리 이상이면 false 반환
+            }
+        }
+
+        return enermyCount == 1; // 최종적으로 1마리일 경우 true 반환
     }
 
 
     // 자기 자신을 제외하고 플레이어의 소환수에 특수공격이 공격형인 스킬이 있는지 확인하는 메소드
-    public bool HasSpecificAvailableSpecialAttack(Summon self, List<Plate> playerPlates)
+    public bool HasSpecificAvailableSpecialAttack(Summon self, int wolfPlateIndex, List<Plate> playerPlates)
     {
         // 검사할 특수 공격 상태 타입들 (None, Burn, Poison, LifeDrain)
         StatusType[] specificStatuses = new StatusType[] { StatusType.None, StatusType.Burn, StatusType.Poison, StatusType.LifeDrain };
 
-        foreach (Plate plate in playerPlates)
+        if (wolfPlateIndex < 2)
         {
-            Summon playerSummon = plate.getCurrentSummon();
-            // 자기 자신을 제외하고 검사
-            if (playerSummon != null && playerSummon != self)
+            for(int i=wolfPlateIndex+1; i< playerPlates.Count; i++)
             {
-                // 소환수의 사용 가능한 특수 공격들을 가져옴
-                IAttackStrategy[] availableSpecialAttacks = playerSummon.getAvailableSpecialAttacks();
-
-                // 사용 가능한 특수 공격 중 특정 상태가 있는지 확인
-                foreach (IAttackStrategy specialAttack in availableSpecialAttacks)
+                Summon playerSummon = playerPlates[i].getCurrentSummon();
+                // 자기 자신을 제외하고 검사
+                if (playerSummon != null && playerSummon != self)
                 {
-                    if (specialAttack != null && specificStatuses.Contains(specialAttack.getStatusType()))
+                    // 소환수의 사용 가능한 특수 공격들을 가져옴
+                    IAttackStrategy[] availableSpecialAttacks = playerSummon.getAvailableSpecialAttacks();
+
+                    // 사용 가능한 특수 공격 중 특정 상태가 있는지 확인
+                    foreach (IAttackStrategy specialAttack in availableSpecialAttacks)
                     {
-                        // 특정 상태가 있는 특수 공격이 있다면 true 반환
-                        return true;
+                        if (specialAttack != null && specificStatuses.Contains(specialAttack.getStatusType()))
+                        {
+                            // 특정 상태가 있는 특수 공격이 있다면 true 반환
+                            return true;
+                        }
                     }
                 }
             }
         }
-        return false; // 특정 상태가 없으면 false 반환
+        return false;
     }
 
 

--- a/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
@@ -449,7 +449,7 @@ public class Summon : MonoBehaviour, UpdateStateObserver
         NotifyObservers();
     }
 
-    public static double multiple=1; //배수설정
+    public static double multiple=5; //배수설정
     public virtual void ApplayMultiple(double m) {
         maxHP = (int)(maxHP * m);
         nowHP = maxHP;
@@ -503,11 +503,11 @@ public class Summon : MonoBehaviour, UpdateStateObserver
         this.summonName = name;
     }
 
-    public double getHeavyAttakPower()
+    public double getHeavyAttackPower()
     {
         return heavyAttakPower;
     }
-    public void setHeavyAttakPower(double value)
+    public void setHeavyAttackPower(double value)
     {
         this.heavyAttakPower = value;
     }


### PR DESCRIPTION
## 수정사항
- 독수리 예측의 10% 미만 기준을 현재 체력이 가장 높은 소환수의 현재체력을 기준으로 삼아서 계산

- 몬스터 한쪽이 다른쪽과 체력을 비교할때 30% 이상 낮은지 검사시 2마리 이상 낮은 몬스터가 존재하면 현재체력이 낮은 몬스터의 인덱스를 반환하게 수정

- 여우의 아군 등급이 모두 하급과 중급인가 로직에 문제가 있었어서 상급 소환수가 인식되자마자 false를 반환시켜 특수공격이 오르지 못하게 수정

## 테스트 하지 못한 로직
- 뱀의 공격의 개수가 4개 이상인 몬스터의 존재
- 토끼의 전체적인 로직(이론상 잘 돌아갈 듯합니다)