### PR TITLE
적 대응 공격 알고리즘 테스트 끝

### DIFF
--- a/Workpiece/Summoner/Assets/Script/Battle/BattleController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleController.cs
@@ -85,16 +85,18 @@ public class BattleController : MonoBehaviour
 
         if (isPlayer) //플레이어
         {
-            if (!IsValidPlateIndex(selectedPlateIndex, plateController.getEnermyPlates().Count))
-            {
-                Debug.Log("유효한 적의 플레이트 인덱스가 선택되지 않았습니다.");
-                return;
-            }
-
+            //아군 버프에 대한 것일경우
             if (targetedAttack.isBenefitEffect(targetedAttack))
             {
                 attackSummon.SpecialAttack(plateController.getPlayerPlates(), selectedPlateIndex, selectSpecialAttackIndex); // 아군 플레이트에 이로운 효과
                 Debug.Log($"플레이어가 선택한 아군의 플레이트 {selectedPlateIndex}가 이로운 효과 대상입니다.");
+                return;
+            }
+            //공격에 대한 것일경우
+            if (!IsValidPlateIndex(selectedPlateIndex, plateController.getEnermyPlates().Count))
+            {
+                Debug.Log("유효한 적의 플레이트 인덱스가 선택되지 않았습니다.");
+                return;
             }
             else
             {
@@ -104,16 +106,16 @@ public class BattleController : MonoBehaviour
         }
         else //적
         {
-            if (!IsValidPlateIndex(selectedPlateIndex, plateController.getPlayerPlates().Count))
-            {
-                Debug.Log("유효한 플레이어의 플레이트 인덱스가 선택되지 않았습니다.");
-                return;
-            }
-
             if (targetedAttack.isBenefitEffect(targetedAttack))
             {
                 attackSummon.SpecialAttack(plateController.getEnermyPlates(), selectedPlateIndex, selectSpecialAttackIndex); // 적 플레이트에 이로운 효과
                 Debug.Log($"적이 선택한 적의 플레이트 {selectedPlateIndex}가 이로운 효과 대상입니다.");
+                return;
+            }
+            if (!IsValidPlateIndex(selectedPlateIndex, plateController.getPlayerPlates().Count))
+            {
+                Debug.Log("유효한 플레이어의 플레이트 인덱스가 선택되지 않았습니다.");
+                return;
             }
             else
             {

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/StatusEffect.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/StatusEffect.cs
@@ -96,6 +96,15 @@ public class StatusEffect
         this.originAttack = originAttack;
     }
 
+    public Summon getAttacker()
+    {
+        return attacker;
+    }
+    public void setAttacker(Summon summon)
+    {
+        attacker = summon;
+    }
+
     public bool shouldApplyOnce()
     {
         return damagePerTurn > 0 && !applyOnce;

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/CatAttackPrediction.cs
@@ -132,14 +132,14 @@ public class CatAttackPrediction : MonoBehaviour, IAttackPrediction
             // 일반 공격 확률을 증가시키고, 특수 공격 확률을 그만큼 감소
             currentProbabilities.normalAttackProbability += AttackChange;
             currentProbabilities.specialAttackProbability -= AttackChange;
-            Debug.Log($"일반 공격 확률이 {AttackChange*100}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+            Debug.Log($"일반 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
         }
         else
         {
             // 특수 공격 확률을 증가시키고, 일반 공격 확률을 그만큼 감소
             currentProbabilities.specialAttackProbability += AttackChange;
             currentProbabilities.normalAttackProbability -= AttackChange;
-            Debug.Log($"특수 공격 확률이 {AttackChange * 100}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
+            Debug.Log($"특수 공격 확률이 {AttackChange}% 증가하였습니다. 이유: {reason}. 현재 확률: 일반 {currentProbabilities.normalAttackProbability}%, 특수 {currentProbabilities.specialAttackProbability}%");
         }
         return currentProbabilities;
     }

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/SnakeAttackPrediction.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Prediction/SnakeAttackPrediction.cs
@@ -32,6 +32,7 @@ public class SnakeAttackPrediction : MonoBehaviour, IAttackPrediction
         {
             if (isEnermyCountOverTwo(enermyPlates)) //적이 2마리 이상인가?
             {
+                attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "뱀 적이 2마리 이상");
                 if (AllEnermyHealthOver50(enermyPlates)) //적의 체력이 모두 50% 이상인가?
                 {
                     attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "뱀 적의 체력이 모두 50%이상");
@@ -40,9 +41,9 @@ public class SnakeAttackPrediction : MonoBehaviour, IAttackPrediction
                 {
                     attackProbability = AdjustAttackProbabilities(attackProbability, 10f, true, "뱀 적의 체력이 모두 50%가 아님");
                 }
-                if (hasMonsterWithMoreThan4Attacks(enermyPlates)) //몬스터 중 공격의 개수가 4개 이상인 몹이 존재하는가?
+                if (hasMonsterWithMoreThan3Attacks(enermyPlates)) //몬스터 중 공격의 개수가 3개 이상인 몹이 존재하는가?
                 {
-                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "뱀 적의 몬스터중 공격이 4개 이상인 몹이 있는가");
+                    attackProbability = AdjustAttackProbabilities(attackProbability, 10f, false, "뱀 적의 몬스터중 공격이 3개 이상인 몹이 있는가");
                 }
             }
             else //1마리 일때
@@ -110,12 +111,12 @@ public class SnakeAttackPrediction : MonoBehaviour, IAttackPrediction
 
 
     // 적 중에 공격 개수가 4개 이상인 소환수가 있는지 확인하는 메소드
-    public bool hasMonsterWithMoreThan4Attacks(List<Plate> enermyPlates)
+    public bool hasMonsterWithMoreThan3Attacks(List<Plate> enermyPlates)
     {
         foreach (Plate plate in enermyPlates)
         {
             Summon enermySummon = plate.getCurrentSummon();
-            if (enermySummon != null && enermySummon.getSpecialAttackCount() >= 4)
+            if (enermySummon != null && enermySummon.getSpecialAttackCount() >= 3)
             {
                 return true;
             }

--- a/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
@@ -253,6 +253,14 @@ public class Summon : MonoBehaviour, UpdateStateObserver
                     takeDamage(effect.damagePerTurn); // 피해 적용
                 }
 
+                // 흡혈 상태일 경우 회복 처리
+                if (effect.statusType == StatusType.LifeDrain && effect.getAttacker() != null)
+                {
+                    double healAmount = effect.damagePerTurn; // 흡혈 데미지만큼 회복
+                    Debug.Log($"{effect.getAttacker()}이(가) {effect.statusType} 상태로 인해 {healAmount}만큼 회복합니다.");
+                    effect.getAttacker().Heal(effect.damagePerTurn);
+                }
+
                 // 지속시간 감소
                 effect.effectTime--;
 


### PR DESCRIPTION
## 버그 수정 내용

- 흡혈시 체력회복이 되지 않던 버그 수정
- 배틀컨트롤러에서 아군에게 힐을 해야할때 적 플레이트의 유효성을 먼저 검사해버려서 스킬사용이 안되던 버그 수정
- 적 대응공격중 일반공격에 소환수가 2마리 이상이고 소환수간 체력차이가 30% 이상 날 경우 현재 체력이 가장 높은 소환수의 인덱스에게 흡혈을 사용하도록 수정