### PR TITLE
StatusEffect Visual Indicator

### DIFF
--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/StatusEffect.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/AttackLogic/StatusEffect.cs
@@ -17,6 +17,7 @@ public enum StatusType
     OnceInvincibility //1È¸ ¹«Àû
 }
 
+[System.Serializable]
 public class StatusEffect
 {
     public StatusType statusType { get; private set; }


### PR DESCRIPTION
상태이상이 걸려있으면 소환수, 몬스터의 색상이 바뀜

독성: 초록
화상: 빨강
스턴: 검정
흡혈: 노랑
쉴드: 원래색상

상태이상이 번갈아가며 깜빡이도록 설정