### PR TITLE
몬스터 수치조정 및 앞당겨지지 않는 버그 픽스

### DIFF
--- a/Workpiece/Summoner/Assets/Screen/Start Screen.unity
+++ b/Workpiece/Summoner/Assets/Screen/Start Screen.unity
@@ -2222,10 +2222,7 @@ RectTransform:
   m_Children:
   - {fileID: 391636849}
   - {fileID: 1015872038}
-  - {fileID: 2004977926}
-  - {fileID: 959661036}
-  - {fileID: 629438703}
-  - {fileID: 1042411687}
+  - {fileID: 1231534422}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -4923,18 +4920,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 629438702}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 3.2111647}
+  m_LocalScale: {x: 0.30196756, y: 0.30196756, z: 0.30196756}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 708676845}
-  m_Father: {fileID: 214920137}
+  m_Father: {fileID: 1231534422}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -493.69473, y: -276.66003}
-  m_SizeDelta: {x: 374.848, y: 126.9417}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &629438704
 MonoBehaviour:
@@ -7890,18 +7887,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 959661035}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 3.2111647}
+  m_LocalScale: {x: 0.30196756, y: 0.30196756, z: 0.30196756}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 136722058}
-  m_Father: {fileID: 214920137}
+  m_Father: {fileID: 1231534422}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -493.69473, y: -124.33003}
-  m_SizeDelta: {x: 374.848, y: 126.9417}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &959661037
 MonoBehaviour:
@@ -8466,18 +8463,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1042411686}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 3.2111647}
+  m_LocalScale: {x: 0.30196756, y: 0.30196756, z: 0.30196756}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 866375059}
-  m_Father: {fileID: 214920137}
+  m_Father: {fileID: 1231534422}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -493.69473, y: -428.99005}
-  m_SizeDelta: {x: 374.848, y: 126.9417}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1042411688
 MonoBehaviour:
@@ -10236,6 +10233,72 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1227138542}
   m_CullTransparentMesh: 1
+--- !u!1 &1231534421
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1231534422}
+  - component: {fileID: 1231534423}
+  m_Layer: 0
+  m_Name: ButtonObjects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1231534422
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1231534421}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10.634138}
+  m_LocalScale: {x: 3.311614, y: 3.311614, z: 3.311614}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2004977926}
+  - {fileID: 959661036}
+  - {fileID: 629438703}
+  - {fileID: 1042411687}
+  m_Father: {fileID: 214920137}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -500, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1231534423
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1231534421}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &1242678097
 GameObject:
   m_ObjectHideFlags: 0
@@ -16419,18 +16482,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2004977925}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 3.2111647}
+  m_LocalScale: {x: 0.30196756, y: 0.30196756, z: 0.30196756}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1824191548}
-  m_Father: {fileID: 214920137}
+  m_Father: {fileID: 1231534422}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -493.6947, y: 28}
-  m_SizeDelta: {x: 374.848, y: 126.9417}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2004977927
 MonoBehaviour:

--- a/Workpiece/Summoner/Assets/Script/Stage/StageSelecter.cs
+++ b/Workpiece/Summoner/Assets/Script/Stage/StageSelecter.cs
@@ -49,23 +49,23 @@ public class StageSelecter : MonoBehaviour
                 SendStory(stage);
                 break;
             case 3:
-                Summon.multiple = 1.5;
+                Summon.multiple = 1.2;
                 SendStory(stage);
                 break;
             case 4:
-                Summon.multiple = 1.5;
+                Summon.multiple = 1.2;
                 SendFight(stage);
                 break;
             case 5:
-                Summon.multiple = 2;
+                Summon.multiple = 1.5;
                 SendStory(stage);
                 break;
             case 6:
-                Summon.multiple = 2;
+                Summon.multiple = 1.5;
                 SendFight(stage);
                 break;
             case 7:
-                Summon.multiple = 4;
+                Summon.multiple = 2.5;
                 SendStory(stage);
                 break;
             // 필요한 스테이지만큼 추가

--- a/Workpiece/Summoner/Assets/Script/Stage/StageText.cs
+++ b/Workpiece/Summoner/Assets/Script/Stage/StageText.cs
@@ -11,6 +11,10 @@ public class StageText : MonoBehaviour
     {
         // PlayerPrefs에서 savedStage 값 불러오기
         int savedStageValue = PlayerPrefs.GetInt("savedStage", 0); // 기본값 0
+        if(savedStageValue > 7)
+        {
+            PlayerPrefs.SetInt("savedStage", 7);
+        }
 
         // 패널에 savedStage 값을 표시
         stageText.text = "<b>[" + savedStageValue.ToString() + " 스테이지 : " + ShowTextSavedStage(savedStageValue) + "]</b>" +

--- a/Workpiece/Summoner/Assets/Script/Start Screen/StartScreenEvent.cs
+++ b/Workpiece/Summoner/Assets/Script/Start Screen/StartScreenEvent.cs
@@ -29,6 +29,7 @@ public class StartScreenEvent : MonoBehaviour
 
     void Start()
     {
+        PlayerPrefs.SetInt("savedStage", 7);
         stageController = FindObjectOfType<StageController>();
         // OptionCanvas_Audio 오브젝트를 씬에서 찾아서 참조
         menuCanvas = GameObject.Find("MenuCanvas");
@@ -47,6 +48,9 @@ public class StartScreenEvent : MonoBehaviour
         else{ Debug.LogError("Setting 버튼이 연결되지 않았습니다."); }
         newAlert.SetActive(false);
         loadAlert.SetActive(false);
+
+        //이어하기 활성화 여부
+        ActiveSavedBtn();
     }
 
     //새게임
@@ -107,6 +111,15 @@ public class StartScreenEvent : MonoBehaviour
                 loadAlert.SetActive(false);
             }
         }));
+    }
+
+    private void ActiveSavedBtn()
+    {
+        int savedStage = PlayerPrefs.GetInt("savedStage");
+        if(savedStage < 1)
+        {
+            loadButton.gameObject.SetActive(false);
+        }
     }
 
     //설정창 끄기 키기

--- a/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
@@ -9,12 +9,12 @@ public class Cat : Summon
     public override void summonInitialize()
     {
         summonName = "Cat";
-        maxHP = 100;
+        maxHP = 250;
         nowHP = maxHP;
-        attackPower = 15; //일반공격
+        attackPower = 30; //일반공격
         summonRank = SummonRank.Low; // 하급 소환수
         summonType = SummonType.Cat;
-        heavyAttakPower = 20;
+        heavyAttakPower = 40;
 
         ApplayMultiple(multiple);
 

--- a/Workpiece/Summoner/Assets/Script/Summons/Eagle.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Eagle.cs
@@ -8,7 +8,7 @@ public class Eagle : Summon
     public override void summonInitialize()
     {
         summonName = "Eagle";
-        maxHP = 400;
+        maxHP = 350;
         nowHP = maxHP;
         attackPower = 45; //일반공격
         summonRank = SummonRank.High; // 상급 소환수

--- a/Workpiece/Summoner/Assets/Script/Summons/Fox.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Fox.cs
@@ -8,9 +8,9 @@ public class Fox : Summon
     public override void summonInitialize()
     {
         summonName = "Fox"; //이름 Fox
-        maxHP = 200; //최대체력 200
+        maxHP = 250; //최대체력 200
         nowHP = maxHP; //현재체력 // 깨어날땐 최대체력으로 설정
-        attackPower = 15; //일반공격
+        attackPower = 35; //일반공격
         summonRank = SummonRank.Low; // 하급 소환수
         summonType = SummonType.Fox;
         ApplayMultiple(multiple);

--- a/Workpiece/Summoner/Assets/Script/Summons/Rabbit.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Rabbit.cs
@@ -14,9 +14,9 @@ public class Rabbit : Summon
     public override void summonInitialize()
     {
         summonName = "Rabbit";
-        maxHP = 250;
+        maxHP = 300;
         nowHP = maxHP;
-        attackPower = 20; //일반공격
+        attackPower = 37; //일반공격
         summonRank = SummonRank.Medium; // 중급 소환수
         summonType = SummonType.Rabbit;
 

--- a/Workpiece/Summoner/Assets/Script/Summons/Snake.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Snake.cs
@@ -12,13 +12,13 @@ public class Snake : Summon
     public override void summonInitialize()
     {
         summonName = "Snake";
-        maxHP = 200;
+        maxHP = 300;
         nowHP = maxHP;
-        attackPower = 30; //일반공격
+        attackPower = 40; //일반공격
         summonRank = SummonRank.Medium; // 중급 소환수
         summonType = SummonType.Snake;
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 1); //근접 공격
-        specialAttackStrategies = new IAttackStrategy[] { new AttackAllEnemiesStrategy(StatusType.Poison, 0.1, 3, 3) };//중독, 체력에10% 쿨타임3턴 지속시간3턴
+        specialAttackStrategies = new IAttackStrategy[] { new AttackAllEnemiesStrategy(StatusType.Poison, 0.2, 3, 3) };//중독, 체력에20% 쿨타임3턴 지속시간3턴
 
         ApplyMultiple(multiple);
     }

--- a/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
@@ -288,12 +288,51 @@ public class Summon : MonoBehaviour, UpdateStateObserver
     }
 
     // 데미지를 주는 상태이상 업데이트 메소드 (예: Poison, Burn 등)
+    //public void UpdateDamageStatusEffects()
+    //{
+    //    List<StatusEffect> expiredEffects = new List<StatusEffect>();
+
+    //    foreach (var effect in activeStatusEffects)
+    //    {
+    //        if (effect != null && effect.effectTime > 0)
+    //        {
+    //            // 데미지 주는 상태 확인 및 처리
+    //            if (effect.damagePerTurn > 0 && effect.statusType != StatusType.Upgrade && effect.statusType != StatusType.Curse)
+    //            {
+    //                Debug.Log($"{summonName}이(가) {effect.statusType} 상태로 인해 {effect.damagePerTurn} 데미지를 입습니다. 남은 상태이상시간: {effect.effectTime} 턴");
+    //                takeDamage(effect.damagePerTurn); // 피해 적용
+    //            }
+
+    //            // 흡혈 상태일 경우 회복 처리
+    //            if (effect.statusType == StatusType.LifeDrain && effect.getAttacker() != null)
+    //            {
+    //                double healAmount = effect.damagePerTurn; // 흡혈 데미지만큼 회복
+    //                Debug.Log($"{effect.getAttacker()}이(가) {effect.statusType} 상태로 인해 {healAmount}만큼 회복합니다.");
+    //                effect.getAttacker().Heal(effect.damagePerTurn);
+    //            }
+
+    //            // 지속시간 감소
+    //            effect.effectTime--;
+
+    //            // 상태가 만료될 경우 만료 리스트에 추가
+    //            if (effect.effectTime <= 0)
+    //            {
+    //                expiredEffects.Add(effect);
+    //            }
+    //        }
+    //    }
+
+    //    RemoveExpiredEffects(expiredEffects);
+    //}
     public void UpdateDamageStatusEffects()
     {
         List<StatusEffect> expiredEffects = new List<StatusEffect>();
 
-        foreach (var effect in activeStatusEffects)
+        // 역순으로 리스트 순회
+        for (int i = activeStatusEffects.Count - 1; i >= 0; i--)
         {
+            var effect = activeStatusEffects[i];
+
             if (effect != null && effect.effectTime > 0)
             {
                 // 데미지 주는 상태 확인 및 처리
@@ -322,7 +361,7 @@ public class Summon : MonoBehaviour, UpdateStateObserver
             }
         }
 
-        RemoveExpiredEffects(expiredEffects);
+        RemoveExpiredEffects(expiredEffects); // 만료된 효과 제거
     }
 
     // 스턴 상태 업데이트 메소드

--- a/Workpiece/Summoner/Assets/Script/Summons/Wolf.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Wolf.cs
@@ -8,10 +8,10 @@ public class Wolf : Summon
     public override void summonInitialize()
     {
         summonName = "Wolf";
-        maxHP = 300;
+        maxHP = 350;
         nowHP = maxHP;
         attackPower = 50; //일반공격
-        heavyAttakPower = 25;
+        heavyAttakPower = 30;
         summonRank = SummonRank.High; // 중급 소환수
         summonType = SummonType.Wolf;
         ApplayMultiple(multiple);


### PR DESCRIPTION
### 배수설정
- 엑셀수치대로 소환수 수치조정 및 스테이지별 배수설정

### 상태이상 로직 수정
- 앞당겨지지 않는 버그는 상태이상데미지를 주는 메소드에서 foreach로 상태이상을 순회하던것을 for문으로 고쳐보았음.

### 이어하기 수정
- PlayerPrefs에 저장된 값이 없으면 이어하기 버튼을 비활성화 시킴.
- 7스테이지 이후에 이어하기하면 8로 나오던것도 saveStage값이 7초과면 7로 설정되게 추가