### PR TITLE
24.11.23 버그픽스

### DIFF
--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/TurnController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/TurnController.cs
@@ -17,8 +17,12 @@ public class TurnController : MonoBehaviour
     [SerializeField] private TextMeshProUGUI turnCountText;
     [SerializeField] private TextMeshProUGUI turnClearText;
 
+    StageController stageController;
+
     void Start()
     {
+        stageController = FindAnyObjectByType<StageController>();
+
         currentTurn = Turn.PlayerTurn; // 첫 번째 턴은 플레이어 턴으로 시작
         turnCount = 1;
         UpdateTurnCountUI();
@@ -42,6 +46,13 @@ public class TurnController : MonoBehaviour
             }
 
             player.getPlateController().CompactEnermyPlates(); //앞당기기
+
+            // 승리 조건
+            if (enermy.getEnermyAttackController().getPlateController().IsEnermyPlateClear() && (player.clearTurn >= player.currentTurn))
+            {
+                Debug.Log("승리!");
+                player.battleAlert.clearAlert(stageController.stageNum);
+            }
 
 
             foreach (var summon in player.getPlateController().getPlayerSummons())

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Player.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Player.cs
@@ -36,12 +36,12 @@ public class Player : Character
     [SerializeField] private BattleController battleController;
     [SerializeField] private PlateController plateController;
 
-    BattleAlert battleAlert;
+    public BattleAlert battleAlert;
 
     private int selectedPlateIndex = -1;
     private int stageNum;
-    private int currentTurn;
-    private int clearTurn;
+    public int currentTurn;
+    public int clearTurn;
     private bool hasSummonedThisTurn;
 
     private void Awake()

--- a/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
@@ -52,7 +52,7 @@ public class Cat : Summon
 
         
         double originAttackPower = attackPower;
-        attackPower = 20;
+        attackPower = heavyAttakPower;
         // 공격 수행
         specialAttack.Attack(this, enemyPlates, selectedPlateIndex, SpecialAttackArrayIndex);
 

--- a/Workpiece/Summoner/Assets/Script/Summons/Fox.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Fox.cs
@@ -17,7 +17,7 @@ public class Fox : Summon
 
         // 일반 공격: 가장 가까운 적 공격
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 0);
-        specialAttackStrategies = new IAttackStrategy[] { new TargetedAttackStrategy(StatusType.Upgrade, 0.2, 3, 1) };//공격력 강화, 20% 상승, 쿨타임 3턴 //지속시간 1턴
+        specialAttackStrategies = new IAttackStrategy[] { new TargetedAttackStrategy(StatusType.Upgrade, 0.3, 3, 1) };//공격력 강화, 20% 상승, 쿨타임 3턴 //지속시간 1턴
 
     }
 

--- a/Workpiece/Summoner/Assets/Script/Summons/Snake.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Snake.cs
@@ -18,7 +18,7 @@ public class Snake : Summon
         summonRank = SummonRank.Medium; // 중급 소환수
         summonType = SummonType.Snake;
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 1); //근접 공격
-        specialAttackStrategies = new IAttackStrategy[] { new AttackAllEnemiesStrategy(StatusType.Poison, 0.2, 3, 3) };//중독, 체력에20% 쿨타임3턴 지속시간3턴
+        specialAttackStrategies = new IAttackStrategy[] { new AttackAllEnemiesStrategy(StatusType.Poison, 0.15, 3, 3) };//중독, 체력에20% 쿨타임3턴 지속시간3턴
 
         ApplyMultiple(multiple);
     }


### PR DESCRIPTION
## 고양이 특수공격 배수설정 적용
- 특수공격 사용시 20으로 고정되어 있던 코드 수정

## 특수공격 수치 재적용 
- 뱀 특수공격 퍼센트 20%->15%
- 여우 특수공격 강화수치 20% -> 30%

## 플레이어 턴 시작시 클리어 로직 적용
- 플레이어 턴 시작시에 공격버튼에 있는 승리조건 로직 Ctrl+C,V 로 넣음