### PR TITLE
고양이 특수공격 수치버그 픽스 및 스테이지 배수설정 안되있던거 추가보수

### DIFF
--- a/Workpiece/Summoner/Assets/Script/Battle/BattleController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleController.cs
@@ -10,7 +10,7 @@ public class BattleController : MonoBehaviour
 
     [SerializeField] private StatePanel statePanel;
 
-    private bool isAttacking = false; //공격중인이 판별
+    public bool isAttacking = false; //공격중인이 판별
 
     private PlateController plateController;
 

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/EnermyAttackController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/EnermyAttackController.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -16,7 +17,6 @@ public class EnermyAttackController : MonoBehaviour
         plateController = enermyAlgorithm.getPlateController();
     }
 
-
     public void EnermyAttackStart(List<AttackPrediction> playerAttackPredictionsList)
     {
         List<Plate> enermyPlate = plateController.getEnermyPlates();
@@ -24,6 +24,7 @@ public class EnermyAttackController : MonoBehaviour
         for (int index = 0; index < plateController.getEnermySummonCount(); index++) //적이 순차적으로 공격준비
         {
             Summon attackingSummon = enermyPlate[index].getCurrentSummon(); //플레이트에 소환수를 차례로 가져와서
+
             // 소환수가 스턴 상태인지 확인
             if (attackingSummon.IsStun())
             {
@@ -51,6 +52,11 @@ public class EnermyAttackController : MonoBehaviour
                 }
             }
         }
+    }
+
+    IEnumerator WaitForEnemyAttacking()
+    {
+        yield return new WaitForSeconds(1f); // 1초 대기
     }
 
     //화상, 흡혈, 독성에 대해서는 힐스킬이 있을경우 힐사용

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/SummonController.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Controller/SummonController.cs
@@ -8,7 +8,7 @@ public class SummonController : MonoBehaviour
 
     [SerializeField] private GameObject darkBackground; // 재소환 배경 처리할 판넬 (반투명)
 
-    private bool isSummoning = false; // 재소환 중인지 확인하는 변수
+    public bool isSummoning = false; // 재소환 중인지 확인하는 변수
 
     [Header("플레이어")]
     [SerializeField] private Player player;

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Enermy.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Enermy.cs
@@ -15,8 +15,8 @@ public class Enermy : Character
 
     BattleAlert battleAlert;
 
-    private int stageNum;
-    private int currentTurn;
+    //private int stageNum;
+    //private int currentTurn;
 
     private void Awake()
     {

--- a/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Player.cs
+++ b/Workpiece/Summoner/Assets/Script/Battle/BattleLogic/Player.cs
@@ -84,6 +84,9 @@ public class Player : Character
 
     public void OnSummonBtnClick()
     {
+        //공격중이거나 소환(재소환포함)중에는 클릭안되게
+        if (summonController.isSummoning || battleController.getIsAttaking()) return;
+
         if (hasSummonedThisTurn)
         {
             failSound.Play();
@@ -120,6 +123,10 @@ public class Player : Character
     //플레이어는 버튼 클릭을 통해서만 턴종료를 시킨다.
     public void PlayerTurnOverBtn() //버튼에 넣을 메소드
     {
+        //공격중이거나 소환(재소환포함)중에는 클릭안되게
+        if (summonController.isSummoning || battleController.getIsAttaking()) return;
+
+
         // 플레이어 턴일 때만 턴 종료 가능
         if (turnController.getCurrentTurn() == TurnController.Turn.PlayerTurn)
         {
@@ -136,6 +143,9 @@ public class Player : Character
 
     public void OnReSummonBtnClick() //재소환 버튼 클릭
     {
+        //공격중이거나 소환(재소환포함)중에는 클릭안되게
+        if (summonController.isSummoning || battleController.getIsAttaking()) return;
+
         if (mana >= usedMana) {
             if (summonController.StartResummon())
             { //재소환 시작
@@ -156,6 +166,9 @@ public class Player : Character
 
     public void OnAttackBtnClick() //일반공격
     {
+        //공격중이거나 소환(재소환포함)중에는 클릭안되게
+        if (summonController.isSummoning || battleController.getIsAttaking()) return;
+
         Summon attackSummon = battleController.attackStart(0); //공격할 소환수를 받아온다.
         if (!attackSummon.getIsAttack() || attackSummon.IsStun()) {
             Debug.Log("공격할 수 없습니다. ");
@@ -186,6 +199,9 @@ public class Player : Character
 
     public void OnSpecialAttackBtnClick() //특수공격
     {
+        //공격중이거나 소환(재소환포함)중에는 클릭안되게
+        if (summonController.isSummoning || battleController.getIsAttaking()) return;
+
         Summon attackSummon = battleController.attackStart(0); // 공격할 소환수를 가져옴
         if (!attackSummon.getIsAttack() || attackSummon.IsStun())
         {
@@ -210,6 +226,7 @@ public class Player : Character
             // TargetedAttackStrategy를 사용하는지 확인
             if (attackStrategy is TargetedAttackStrategy targetedAttack)
             {
+                battleController.setIsAttaking(true);
                 StatusType attackStatusType = targetedAttack.getStatusType();
                 clickSound.Play();
                 if (attackStatusType == StatusType.Heal || attackStatusType == StatusType.Upgrade || attackStatusType == StatusType.Shield) //타겟중에 힐일경우

--- a/Workpiece/Summoner/Assets/Script/Stage/StageController.cs
+++ b/Workpiece/Summoner/Assets/Script/Stage/StageController.cs
@@ -63,23 +63,23 @@ public class StageController : MonoBehaviour
                 break;
             case 3:
                 SendStory(stage);
-                Summon.multiple = 1.5;
+                Summon.multiple = 1.2;
                 break;
             case 4:
                 SendFight(stage);
-                Summon.multiple = 1.5;
+                Summon.multiple = 1.2;
                 break;
             case 5:
                 SendStory(stage);
-                Summon.multiple = 2;
+                Summon.multiple = 1.5;
                 break;
             case 6:
                 SendFight(stage);
-                Summon.multiple = 2;
+                Summon.multiple = 1.5;
                 break;
             case 7:
                 SendStory(stage);
-                Summon.multiple = 4;
+                Summon.multiple = 2.5;
                 break;
             // 필요한 스테이지만큼 추가
             default:

--- a/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Cat.cs
@@ -25,6 +25,34 @@ public class Cat : Summon
 
     }
 
+    public override void SpecialAttack(List<Plate> enemyPlates, int selectedPlateIndex, int SpecialAttackArrayIndex)
+    {
+        if (SpecialAttackArrayIndex < 0 || SpecialAttackArrayIndex >= specialAttackStrategies.Length)
+        {
+            Debug.Log("유효하지 않은 특수 공격 인덱스입니다.");
+            return;
+        }
+
+        var specialAttack = specialAttackStrategies[SpecialAttackArrayIndex];
+
+        if (specialAttack == null || specialAttack.getCurrentCooldown() > 0)
+        {
+            Debug.Log("특수 스킬이 쿨타임 중입니다.");
+            return;
+        }
+
+
+        double originAttackPower = attackPower;
+        attackPower = heavyAttakPower;
+
+        specialAttack.Attack(this, enemyPlates, selectedPlateIndex, SpecialAttackArrayIndex);
+        animator.SetTrigger("attack");
+        StartCoroutine(ColorChange(1)); // 검정색
+        specialAttack.ApplyCooldown();
+        attackPower = originAttackPower;
+        isAttack = false;
+    }
+
     public override void ApplayMultiple(double multiple)
     {
         maxHP = (int)(maxHP * multiple);

--- a/Workpiece/Summoner/Assets/Script/Summons/Snake.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Snake.cs
@@ -18,7 +18,7 @@ public class Snake : Summon
         summonRank = SummonRank.Medium; // 중급 소환수
         summonType = SummonType.Snake;
         attackStrategy = new ClosestEnemyAttackStrategy(StatusType.None, attackPower, 1); //근접 공격
-        specialAttackStrategies = new IAttackStrategy[] { new AttackAllEnemiesStrategy(StatusType.Poison, 0.15, 3, 3) };//중독, 체력에20% 쿨타임3턴 지속시간3턴
+        specialAttackStrategies = new IAttackStrategy[] { new AttackAllEnemiesStrategy(StatusType.Poison, 0.1, 3, 2) };//중독, 체력에20% 쿨타임3턴 지속시간3턴
 
         ApplyMultiple(multiple);
     }

--- a/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
+++ b/Workpiece/Summoner/Assets/Script/Summons/Summon.cs
@@ -19,10 +19,10 @@ public enum SummonType
 
 public class Summon : MonoBehaviour, UpdateStateObserver
 {
-    [SerializeField] private Image image; //이미지
-    [SerializeField] private Sprite[] sprites; // 스프라이트 모음
-    [SerializeField] private GameObject shieldImage;
-    [SerializeField] private Animator animator;
+    [SerializeField] protected Image image; //이미지
+    [SerializeField] protected Sprite[] sprites; // 스프라이트 모음
+    [SerializeField] protected GameObject shieldImage;
+    [SerializeField] protected Animator animator;
 
     [Header("효과음")]
     [SerializeField] public AudioSource attackSound;
@@ -88,7 +88,7 @@ public class Summon : MonoBehaviour, UpdateStateObserver
         isAttack = false;
     }
 
-    IEnumerator ColorChange(int color)    // 색이 변했다가 돌아옴
+    protected IEnumerator ColorChange(int color)    // 색이 변했다가 돌아옴
     {
         //
         attakingMotion = true;


### PR DESCRIPTION
### 고양이 특수공격 수정
- 삭제 시켜버렸던 특수공격 코드 복구하고 공격애니메이션과 색상변경을 protected로하여 Summon의 자식클래스들도 사용가능하도록 수정

### 스테이지 배수 설정 수정
- 스테이지 선택에서 버튼으로 넘어오는 배수는 잘 되고있었지만 스테이지 클리어로 넘어오는 배수는 이전 배수로 되있던 코드 수정

### 소환, 소환중 버튼클릭 수정
- 공격, 소환(재소환)중 버튼이 클릭이 가능한 버그 수정
